### PR TITLE
Fix from Result.ok("文件导入失败！") to Result.error("文件导入失败！")

### DIFF
--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/controller/SysCategoryController.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/controller/SysCategoryController.java
@@ -249,7 +249,7 @@ public class SysCategoryController {
               }
           }
       }
-      return Result.ok("文件导入失败！");
+      return Result.error("文件导入失败！");
   }
   
   

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/controller/SysCategoryController.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/controller/SysCategoryController.java
@@ -237,10 +237,10 @@ public class SysCategoryController {
               for (SysCategory sysCategoryExcel : listSysCategorys) {
                   sysCategoryService.save(sysCategoryExcel);
               }
-              return Result.ok("文件导入成功！数据行数:" + listSysCategorys.size());
+              return Result.ok("文件导入成功！数据行数：" + listSysCategorys.size());
           } catch (Exception e) {
-              log.error(e.getMessage(),e);
-              return Result.error("文件导入失败:"+e.getMessage());
+              log.error(e.getMessage(), e);
+              return Result.error("文件导入失败：" + e.getMessage());
           } finally {
               try {
                   file.getInputStream().close();


### PR DESCRIPTION
This PR is a simple fix and two minor reformats.

### Fix
- `Result.ok("文件导入失败！");` was changed to `Result.error("文件导入失败！");` in `SysCategoryController.java$importExcel()`

### Reformat
- A half-width colon was aligned with a full-width colon. ( from `:` to `：` ) 
- Spaces were inserted.

Reformats were based on similar code fragments in this repository, as described below.
https://github.com/zhangdaiscott/jeecg-boot/blob/d399ec904ab7ace79c78b59271b97aa2bf4bd945/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/controller/QuartzJobController.java#L242-L248
https://github.com/zhangdaiscott/jeecg-boot/blob/d399ec904ab7ace79c78b59271b97aa2bf4bd945/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/controller/SysUserAgentController.java#L240-L246
