### PR TITLE
修复路由传参的值传送到jinput框被前后各截取了一位

### DIFF
--- a/ant-design-vue-jeecg/src/components/jeecg/JInput.vue
+++ b/ant-design-vue-jeecg/src/components/jeecg/JInput.vue
@@ -56,7 +56,10 @@
           let text = this.value
           switch (this.type) {
             case JINPUT_QUERY_LIKE:
-              text = text.substring(1,text.length-1);
+            //修复路由传参的值传送到jinput框被前后各截取了一位
+            if(text.indexOf("*") != -1){
+                text = text.substring(1,text.length-1);
+              }
               break;
             case JINPUT_QUERY_NE:
               text = text.substring(1);


### PR DESCRIPTION
当有两个界面A,B时，B页面采用的是JInput框，A界面路由传参到B，B接收后将值显示在JInput框时，发现JInput框中的值前后个被截取了一位