### PR TITLE
增加全局字典翻译以及缓存支持，提高字典翻译速度,实测120ms左右，优化后20ms左右

### DIFF
--- a/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/aspect/annotation/DictField.java
+++ b/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/aspect/annotation/DictField.java
@@ -1,0 +1,44 @@
+package org.jeecg.common.aspect.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 字典翻译具体属性
+ *
+ * @author zxiaozhou
+ * @date 2020-06-22 17:27
+ * @since JDK1.8
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DictField {
+    /**
+     * 方法描述:  数据code
+     * 作    者： dangzhenghui
+     * 日    期： 2019年03月17日-下午9:37:16
+     *
+     * @return 返回类型： String
+     */
+    String dicCode();
+
+    /**
+     * 方法描述:  数据Text
+     * 作    者： dangzhenghui
+     * 日    期： 2019年03月17日-下午9:37:16
+     *
+     * @return 返回类型： String
+     */
+    String dicText() default "";
+
+    /**
+     * 方法描述: 数据字典表
+     * 作    者： dangzhenghui
+     * 日    期： 2019年03月17日-下午9:37:16
+     *
+     * @return 返回类型： String
+     */
+    String dictTable() default "";
+}

--- a/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/aspect/annotation/DictMethod.java
+++ b/jeecg-boot/jeecg-boot-base-common/src/main/java/org/jeecg/common/aspect/annotation/DictMethod.java
@@ -1,0 +1,18 @@
+package org.jeecg.common.aspect.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 需要字典翻译的方法
+ *
+ * @author zxiaozhou
+ * @date 2020-06-22 17:27
+ * @since JDK1.8
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DictMethod {
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/Constant.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/Constant.java
@@ -1,0 +1,46 @@
+package org.jeecg.modules.system.aspect;
+
+/**
+ * 类型
+ *
+ * @author zxiaozhou
+ * @date 2020-07-22 12:21
+ * @since JDK1.8
+ */
+public interface Constant {
+    /**
+     * 具体实体
+     */
+    int TYPE_CLASS = 1;
+    /**
+     * list
+     */
+    int TYPE_LIST = 2;
+    /**
+     * set
+     */
+    int TYPE_SET = 3;
+    /**
+     * page dto
+     */
+    int TYPE_PAGE_DTO = 5;
+    /**
+     * page
+     */
+    int TYPE_PAGE = 6;
+
+    /**
+     * boolean类型
+     */
+    int FILE_TYPE_BOOLEAN = 7;
+
+    /**
+     * int类型
+     */
+    int FILE_TYPE_INT = 8;
+
+    /**
+     * 字符串
+     */
+    int FILE_TYPE_STRING = 9;
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/DictAspect2.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/DictAspect2.java
@@ -1,0 +1,375 @@
+package org.jeecg.modules.system.aspect;
+
+import com.alibaba.fastjson.JSONObject;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.jeecg.common.api.vo.Result;
+import org.jeecg.common.aspect.annotation.DictField;
+import org.jeecg.common.constant.CommonConstant;
+import org.jeecg.common.util.oConvertUtils;
+import org.jeecg.modules.system.aspect.model.FieldInfo;
+import org.jeecg.modules.system.aspect.model.TranslateInfo;
+import org.jeecg.modules.system.service.ISysDictService;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 全局字典翻译
+ *
+ * @author zxiaozhou
+ * @date 2020-07-22 11:13
+ * @since JDK1.8
+ */
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DictAspect2 {
+
+    private final ISysDictService dictService;
+
+
+    /**
+     * 反射缓存
+     */
+    private final static Map<String, TranslateInfo> REFLECT_CACHE = new ConcurrentHashMap<>(128);
+
+    /**
+     * 标记是否需要翻译
+     */
+    private final static Map<String, Boolean> ENABLE_TRANSLATE = new ConcurrentHashMap<>(128);
+
+
+    /**
+     * 切点(使用在方法上添加注解提高性能,避免所有都切入)
+     *
+     * @author zxiaozhou
+     * @date 2020-07-22 11:18
+     */
+    @Pointcut("@annotation(org.jeecg.common.aspect.annotation.DictMethod)")
+    public void invoke() {
+    }
+
+
+    /**
+     * 环绕
+     *
+     * @param pjp ${@link ProceedingJoinPoint}
+     * @return Object ${@link Object}
+     * @author zxiaozhou
+     * @date 2020-07-22 11:18
+     */
+    @Around("invoke()")
+    public Object doAround(ProceedingJoinPoint pjp) throws Throwable {
+        log.debug("------------DictAspect------------>doAround:{}", "进行字典翻译");
+        long startTime = System.currentTimeMillis();
+        Object result = pjp.proceed();
+        Signature signature = pjp.getSignature();
+        long endTime = System.currentTimeMillis();
+        log.debug("------------DictAspect-------获取json数据耗时----->doAround:{}", (endTime - startTime) + "ms");
+        Object finalResult = this.parseDict(result, signature);
+        endTime = System.currentTimeMillis();
+        log.debug("------------DictAspect-------字典翻译总耗时----->doAround:{}", (endTime - startTime) + "ms");
+        return finalResult;
+    }
+
+
+    /**
+     * 翻译字典
+     *
+     * @param result    ${@link Object}
+     * @param signature ${@link Signature}
+     * @author zxiaozhou
+     * @date 2020-07-22 11:44
+     */
+    private Object parseDict(Object result, Signature signature) {
+        // 缓存key类路径+方法名
+        String cacheKey = signature.getDeclaringTypeName() + signature.getName();
+        // 如果标记信息为null则去解析反射信息
+        if (Objects.isNull(ENABLE_TRANSLATE.get(cacheKey))) {
+            long startTime = System.currentTimeMillis();
+            log.debug("------------DictAspect------解析字典翻译信息------>parseDict");
+            getCache(result, cacheKey);
+            long endTime = System.currentTimeMillis();
+            log.debug("------------DictAspect-------解析字典翻译信息耗时----->parseDict:{}", (endTime - startTime) + "ms");
+        }
+        return startTranslation(result, cacheKey);
+    }
+
+
+    /**
+     * 获取字典翻译反射信息
+     *
+     * @param result   ${@link Object} 原始数据
+     * @param cacheKey ${@link String} 缓存key
+     * @author zxiaozhou
+     * @date 2020-07-22 11:48
+     */
+    private void getCache(Object result, String cacheKey) {
+        if (result instanceof Result) {
+            Result resultInfo = (Result) result;
+            Object data = resultInfo.getResult();
+            TranslateInfo translateInfo = new TranslateInfo();
+            translateInfo.setType(Constant.TYPE_CLASS);
+            if (Objects.isNull(data)) {
+                return;
+            }
+            Object finalOneData = data;
+            if (data instanceof List) {
+                translateInfo.setType(Constant.TYPE_LIST);
+                List list = (List) data;
+                if (list.isEmpty()) {
+                    return;
+                }
+                finalOneData = list.get(0);
+            } else if (data instanceof Set) {
+                Set sets = (Set) data;
+                if (sets.isEmpty()) {
+                    return;
+                }
+                translateInfo.setType(Constant.TYPE_SET);
+                for (Object obj : sets) {
+                    finalOneData = obj;
+                    break;
+                }
+            } else if (data instanceof IPage) {
+                translateInfo.setType(Constant.TYPE_PAGE);
+                List list = ((IPage) data).getRecords();
+                if (CollectionUtils.isEmpty(list)) {
+                    return;
+                }
+                finalOneData = list.get(0);
+            }
+            if (Objects.nonNull(finalOneData)) {
+                Class<?> aClass = finalOneData.getClass();
+                if (Objects.isNull(aClass)) {
+                    return;
+                }
+                translateInfo.setAClass(aClass);
+                Field[] declaredFields = aClass.getDeclaredFields();
+                List<FieldInfo> fieldInfos = new ArrayList<>();
+                for (Field field : declaredFields) {
+                    FieldInfo fieldInfo = new FieldInfo();
+                    DictField dictField = AnnotationUtils.findAnnotation(field, DictField.class);
+                    if (Objects.nonNull(dictField)) {
+                        fieldInfo.setDictField(dictField);
+                        fieldInfo.setField(field);
+                        fieldInfo.setFiledName(field.getName());
+                        Class<?> type = field.getType();
+                        fieldInfo.setFileTypeClass(type);
+                        fieldInfo.setFileType(getBasicType(type.getName()));
+                        fieldInfos.add(fieldInfo);
+                    }
+                }
+                if (!fieldInfos.isEmpty()) {
+                    translateInfo.setFieldInfos(fieldInfos);
+                    REFLECT_CACHE.put(cacheKey, translateInfo);
+                    ENABLE_TRANSLATE.put(cacheKey, true);
+                } else {
+                    ENABLE_TRANSLATE.put(cacheKey, false);
+                }
+                return;
+            }
+            return;
+        }
+        ENABLE_TRANSLATE.put(cacheKey, false);
+    }
+
+
+    /**
+     * 开始翻译
+     *
+     * @param result   ${@link Object} 原始数据
+     * @param cacheKey ${@link String} 缓存key
+     * @return Object ${@link Object} 翻译后数据
+     * @author zxiaozhou
+     * @date 2020-07-22 11:49
+     */
+    private Object startTranslation(Object result, String cacheKey) {
+        Boolean translate = ENABLE_TRANSLATE.get(cacheKey);
+        TranslateInfo translateInfo = REFLECT_CACHE.get(cacheKey);
+        // 开始翻译字典
+        if (Objects.nonNull(translate) && translate && Objects.nonNull(translateInfo)) {
+            Result resultInfo = (Result) result;
+            Object data = resultInfo.getResult();
+            if (Objects.nonNull(data)) {
+                int type = translateInfo.getType();
+                // 单个对象
+                if (type == Constant.TYPE_CLASS) {
+                    data = setData(data, translateInfo);
+                    // list
+                } else if (type == Constant.TYPE_LIST) {
+                    List<?> objectList = (List<?>) data;
+                    if (!objectList.isEmpty()) {
+                        List<Object> objectNewList = new ArrayList<>(4);
+                        for (Object object : objectList) {
+                            Object translateData = setData(object, translateInfo);
+                            objectNewList.add(translateData);
+                        }
+                        if (!objectNewList.isEmpty()) {
+                            data = objectNewList;
+                        }
+                    }
+                    // set
+                } else if (type == Constant.TYPE_SET) {
+                    Set<?> objectSet = (Set<?>) data;
+                    if (!objectSet.isEmpty()) {
+                        Set<Object> objectNewSet = new HashSet<>(4);
+                        for (Object object : objectSet) {
+                            Object translateData = setData(object, translateInfo);
+                            objectNewSet.add(translateData);
+                        }
+                        if (!objectNewSet.isEmpty()) {
+                            data = objectNewSet;
+                        }
+                    }
+                    // 分页
+                } else if (type == Constant.TYPE_PAGE) {
+                    Page objectPage = (Page) data;
+                    List<?> records = objectPage.getRecords();
+                    if (!CollectionUtils.isEmpty(records)) {
+                        List recordsNew = new ArrayList(4);
+                        for (Object object : records) {
+                            Object translateData = setData(object, translateInfo);
+                            recordsNew.add(translateData);
+                        }
+                        if (!recordsNew.isEmpty()) {
+                            objectPage.setRecords(recordsNew);
+                        }
+                    }
+                    data = objectPage;
+                }
+            }
+            resultInfo.setResult(data);
+            return resultInfo;
+        }
+        return result;
+    }
+
+
+    /**
+     * 数据值处理
+     *
+     * @param oneData       ${@link Object} 单条具体待翻译数据
+     * @param translateInfo ${@link TranslateInfo} 翻译信息
+     * @return Object ${@link Object} 翻译后的数据
+     * @author zxiaozhou
+     * @date 2020-07-22 13:00
+     */
+    private Object setData(Object oneData, TranslateInfo translateInfo) {
+        if (Objects.nonNull(oneData)) {
+            List<FieldInfo> fieldInfos = translateInfo.getFieldInfos();
+            ObjectMapper mapper = new ObjectMapper();
+            String json;
+            try {
+                // 解决@JsonFormat注解解析不了的问题详见(先调JsonFormat处理数据,否则最后转为json后类型注解丢失导致无法解析)
+                json = mapper.writeValueAsString(oneData);
+            } catch (JsonProcessingException e) {
+                log.debug("------------DictAspect------JSON解析失败------>setData:{}", e.getMessage());
+                // 解析异常直接返回原始数据
+                return oneData;
+            }
+            JSONObject jsonObject = JSONObject.parseObject(json);
+            boolean isTranslate = false;
+            for (FieldInfo fieldInfo : fieldInfos) {
+                DictField dictField = fieldInfo.getDictField();
+                String code = dictField.dicCode();
+                String text = dictField.dicText();
+                String table = dictField.dictTable();
+                String key = fieldInfo.getFiledName();
+                Object object = jsonObject.get(key);
+                //翻译字典值对应的txt
+                if (Objects.nonNull(object)) {
+                    String textValue = translateDictValue(code, text, table, key);
+                    log.debug(" 字典Val : " + textValue);
+                    log.debug(" __翻译字典字段__ " + key + CommonConstant.DICT_TEXT_SUFFIX + "： " + textValue);
+                    jsonObject.put(key + CommonConstant.DICT_TEXT_SUFFIX, textValue);
+                    isTranslate = true;
+                }
+            }
+            if (isTranslate) {
+                oneData = jsonObject;
+            }
+        }
+        return oneData;
+    }
+
+
+    /**
+     * 获取基本类型
+     *
+     * @param fileTypeName ${@link String} 属性类型类
+     * @return int ${@link Integer} 基本类型标记
+     * @author zxiaozhou
+     * @date 2020-07-22 17:09
+     */
+    public int getBasicType(String fileTypeName) {
+        int type;
+        switch (fileTypeName) {
+            case "int":
+            case "com.lang.Integer":
+                type = Constant.FILE_TYPE_INT;
+                break;
+            case "boolean":
+            case "com.lang.Boolean":
+                type = Constant.FILE_TYPE_BOOLEAN;
+                break;
+            default:
+                type = 9;
+        }
+        return type;
+    }
+
+    /**
+     * 翻译字典文本
+     *
+     * @param code
+     * @param text
+     * @param table
+     * @param key
+     * @return
+     */
+    private String translateDictValue(String code, String text, String table, String key) {
+        if (oConvertUtils.isEmpty(key)) {
+            return null;
+        }
+        StringBuffer textValue = new StringBuffer();
+        String[] keys = key.split(",");
+        for (String k : keys) {
+            String tmpValue = null;
+            log.debug(" 字典 key : " + k);
+            if (k.trim().length() == 0) {
+                continue; //跳过循环
+            }
+            if (!org.springframework.util.StringUtils.isEmpty(table)) {
+                log.debug("--DictAspect------dicTable=" + table + " ,dicText= " + text + " ,dicCode=" + code);
+                tmpValue = dictService.queryTableDictTextByKey(table, text, code, k.trim());
+            } else {
+                tmpValue = dictService.queryDictTextByKey(code, k.trim());
+            }
+
+            if (tmpValue != null) {
+                if (!"".equals(textValue.toString())) {
+                    textValue.append(",");
+                }
+                textValue.append(tmpValue);
+            }
+
+        }
+        return textValue.toString();
+    }
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/model/FieldInfo.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/model/FieldInfo.java
@@ -1,0 +1,44 @@
+package org.jeecg.modules.system.aspect.model;
+
+import lombok.Data;
+import org.jeecg.common.aspect.annotation.DictField;
+
+import java.lang.reflect.Field;
+
+/**
+ * 实体信息
+ *
+ * @author zhou
+ * @date 2019-11-26 12:41
+ * @since JDK1.8
+ */
+@Data
+public class FieldInfo {
+    private static final long serialVersionUID = 2524981871601153757L;
+    /**
+     * 实体属性名称
+     */
+    private String filedName;
+
+    /**
+     * 属性信息系
+     */
+    private Field field;
+
+    /**
+     * 实体上注解
+     */
+    private DictField dictField;
+
+
+    /**
+     * 待翻译字段类型
+     */
+    private Class<?> fileTypeClass;
+
+    /**
+     * 类型
+     */
+    private int fileType;
+
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/model/TranslateInfo.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/system/aspect/model/TranslateInfo.java
@@ -1,0 +1,33 @@
+package org.jeecg.modules.system.aspect.model;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * 翻译信息
+ *
+ * @author zhou
+ * @date 2019-11-26 12:37
+ * @since JDK1.8
+ */
+@Data
+public class TranslateInfo implements Serializable {
+    private static final long serialVersionUID = -5058630416611762799L;
+    /**
+     * 实体属性信息
+     */
+    List<FieldInfo> fieldInfos;
+
+    /**
+     * 参数类型:1-实体,2-List,3-Set,3-JSONArray,4-PageDto,5-Page
+     */
+    private int type;
+
+    /**
+     * 待翻译数据具体实体类型
+     */
+    private Class<?> aClass;
+
+}


### PR DESCRIPTION
## 改进地方：

1. aop字典翻译除增加反射缓存减少下次处理速度。实测第一次翻译120ms左右,第二次翻译速度能减少到20ms左右
2. 增加两个注解以便控制aop拦截数量，做到精准处理。

## 使用方法：

1. 在需要翻译的controller接口方法上添加DictMethod以便aop进行拦截(使用注解为了减少aop接口数量)；
2. 在响应实体中具体需要翻译的属性上添加DictField注解，以便第一次响应缓存反射信息。