### PR TITLE
修改定时器使用id区分，添加定时器支持通过springId执行指定方法

### DIFF
--- a/ant-design-vue-jeecg/src/views/system/QuartzJobList.vue
+++ b/ant-design-vue-jeecg/src/views/system/QuartzJobList.vue
@@ -225,7 +225,7 @@
           title:"确认暂停",
           content:"是否暂停选中任务?",
           onOk: function(){
-            getAction(that.url.pause,{jobClassName:record.jobClassName}).then((res)=>{
+            getAction(that.url.pause,{id:record.id}).then((res)=>{
               if(res.success){
                 that.$message.success(res.message);
                 that.loadData();
@@ -245,7 +245,7 @@
           title:"确认启动",
           content:"是否启动选中任务?",
           onOk: function(){
-            getAction(that.url.resume,{jobClassName:record.jobClassName}).then((res)=>{
+            getAction(that.url.resume,{id:record.id}).then((res)=>{
               if(res.success){
                 that.$message.success(res.message);
                 that.loadData();

--- a/jeecg-boot/db/jeecgboot-mysql-5.7.sql
+++ b/jeecg-boot/db/jeecgboot-mysql-5.7.sql
@@ -4071,6 +4071,8 @@ CREATE TABLE `sys_quartz_job`  (
   `update_by` varchar(32) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '修改人',
   `update_time` datetime(0) NULL DEFAULT NULL COMMENT '修改时间',
   `job_class_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '任务类名',
+  `spring_id` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'springBean名',
+  `spring_method_name` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'spring执行方法',
   `cron_expression` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT 'cron表达式',
   `parameter` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '参数',
   `description` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '描述',
@@ -4082,9 +4084,9 @@ CREATE TABLE `sys_quartz_job`  (
 -- ----------------------------
 -- Records of sys_quartz_job
 -- ----------------------------
-INSERT INTO `sys_quartz_job` VALUES ('df26ecacf0f75d219d746750fe84bbee', NULL, NULL, 0, 'admin', '2020-05-02 15:40:35', 'org.jeecg.modules.quartz.job.SampleParamJob', '0/1 * * * * ?', 'scott', '带参测试 后台将每隔1秒执行输出日志', -1);
-INSERT INTO `sys_quartz_job` VALUES ('a253cdfc811d69fa0efc70d052bc8128', 'admin', '2019-03-30 12:44:48', 0, 'admin', '2020-05-02 15:48:49', 'org.jeecg.modules.quartz.job.SampleJob', '0/1 * * * * ?', NULL, NULL, -1);
-INSERT INTO `sys_quartz_job` VALUES ('5b3d2c087ad41aa755fc4f89697b01e7', 'admin', '2019-04-11 19:04:21', 0, 'admin', '2020-05-02 15:48:48', 'org.jeecg.modules.message.job.SendMsgJob', '0/50 * * * * ? *', NULL, NULL, -1);
+INSERT INTO `sys_quartz_job` VALUES ('df26ecacf0f75d219d746750fe84bbee', NULL, NULL, 0, 'admin', '2020-05-02 15:40:35', 'org.jeecg.modules.quartz.job.SampleParamJob',NULL,NULL, '0/1 * * * * ?', 'scott', '带参测试 后台将每隔1秒执行输出日志', -1);
+INSERT INTO `sys_quartz_job` VALUES ('a253cdfc811d69fa0efc70d052bc8128', 'admin', '2019-03-30 12:44:48', 0, 'admin', '2020-05-02 15:48:49', 'org.jeecg.modules.quartz.job.SampleJob',NULL,NULL, '0/1 * * * * ?', NULL, NULL, -1);
+INSERT INTO `sys_quartz_job` VALUES ('5b3d2c087ad41aa755fc4f89697b01e7', 'admin', '2019-04-11 19:04:21', 0, 'admin', '2020-05-02 15:48:48', 'org.jeecg.modules.message.job.SendMsgJob',NULL,NULL, '0/50 * * * * ? *', NULL, NULL, -1);
 
 -- ----------------------------
 -- Table structure for sys_role

--- a/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/controller/JoaDemoController.java
+++ b/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/controller/JoaDemoController.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.jeecg.common.api.vo.Result;
 import org.jeecg.common.system.query.QueryGenerator;
+import org.jeecg.common.util.SpringContextUtils;
 import org.jeecg.common.util.oConvertUtils;
 import org.jeecg.modules.demo.test.entity.JoaDemo;
 import org.jeecg.modules.demo.test.service.IJoaDemoService;
@@ -20,6 +21,7 @@ import org.jeecgframework.poi.excel.def.NormalExcelConstants;
 import org.jeecgframework.poi.excel.entity.ExportParams;
 import org.jeecgframework.poi.excel.entity.ImportParams;
 import org.jeecgframework.poi.excel.view.JeecgEntityExcelView;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -240,5 +242,4 @@ public class JoaDemoController {
       }
       return Result.ok("文件导入失败！");
   }
-
-}
+ }

--- a/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/service/ITestSpringBean.java
+++ b/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/service/ITestSpringBean.java
@@ -1,0 +1,5 @@
+package org.jeecg.modules.demo.test.service;
+
+public interface ITestSpringBean {
+	public void test(String msg);
+}

--- a/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/service/impl/TestSpringBean.java
+++ b/jeecg-boot/jeecg-boot-module-demo/src/main/java/org/jeecg/modules/demo/test/service/impl/TestSpringBean.java
@@ -1,0 +1,14 @@
+package org.jeecg.modules.demo.test.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jeecg.modules.demo.test.service.ITestSpringBean;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TestSpringBean implements ITestSpringBean {
+	@Override
+	public void test(String msg) {
+		log.error("传入消息是==="+msg);
+	}
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/controller/QuartzJobController.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/controller/QuartzJobController.java
@@ -317,13 +317,4 @@ public class QuartzJobController {
 		}
 		return Result.ok("执行成功!");
 	}
-	@GetMapping("/test")
-	public Result<?> test(@RequestParam(name = "id", required = true) String id) {
-		String[] all = SpringUtils.getAllBean();
-		StringBuilder sb=new StringBuilder();
-		for(String str:all){
-			sb.append(str+",");
-		}
-		return Result.ok(sb.toString());
-	}
 }

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/controller/QuartzJobController.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/controller/QuartzJobController.java
@@ -133,7 +133,7 @@ public class QuartzJobController {
 
 			if(jobClassName.startsWith("spring:")){
 				String springStr=jobClassName.substring(7,jobClassName.length());
-				String[] springStrs=springStr.split(".");
+				String[] springStrs=springStr.split("\\.");
 				if(springStrs!=null&&springStrs.length==2){
 					quartzJob.setSpringId(springStrs[0]);
 					quartzJob.setSpringMethodName(springStrs[1]);

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/entity/QuartzJob.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/entity/QuartzJob.java
@@ -45,6 +45,16 @@ public class QuartzJob implements Serializable {
 	/**任务类名*/
 	@Excel(name="任务类名",width=40)
 	private java.lang.String jobClassName;
+	/**
+	 * spring bean
+	 */
+	@Excel(name="spring bean ID",width=30)
+	private String springId;
+	/**
+	 * 任务调用的方法名
+	 */
+	@Excel(name="spring方法名",width=15)
+	private String springMethodName;
 	/**cron表达式*/
 	@Excel(name="cron表达式",width=30)
 	private java.lang.String cronExpression;

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/job/SpringJob.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/job/SpringJob.java
@@ -1,0 +1,22 @@
+package org.jeecg.modules.quartz.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jeecg.modules.quartz.entity.QuartzJob;
+import org.jeecg.modules.quartz.util.TaskUtil;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+@Slf4j
+public class SpringJob implements Job {
+
+		@Override
+		public void execute(JobExecutionContext context) throws JobExecutionException {
+			QuartzJob scheduleJob = (QuartzJob) context.getMergedJobDataMap().get("scheduleJob");
+				log.error("任务执行 = [" + scheduleJob.getSpringId()+"."+scheduleJob.getSpringMethodName() + "]----------启动开始");
+				TaskUtil.invokMethod(scheduleJob);
+				log.error("任务执行 = [" + scheduleJob.getSpringId()+"."+scheduleJob.getSpringMethodName() + "]----------执行结束");
+
+
+		}
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
@@ -3,10 +3,12 @@ package org.jeecg.modules.quartz.service.impl;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.jeecg.common.constant.CommonConstant;
 import org.jeecg.common.exception.JeecgBootException;
 import org.jeecg.common.util.DateUtils;
 import org.jeecg.modules.quartz.entity.QuartzJob;
+import org.jeecg.modules.quartz.job.SpringJob;
 import org.jeecg.modules.quartz.mapper.QuartzJobMapper;
 import org.jeecg.modules.quartz.service.IQuartzJobService;
 import org.quartz.*;
@@ -48,7 +50,7 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	public boolean saveAndScheduleJob(QuartzJob quartzJob) {
 		if (CommonConstant.STATUS_NORMAL.equals(quartzJob.getStatus())) {
 			// 定时器添加
-			this.schedulerAdd(quartzJob.getJobClassName().trim(), quartzJob.getCronExpression().trim(), quartzJob.getParameter());
+			this.schedulerAdd(quartzJob);
 		}
 		// DB设置修改
 		quartzJob.setDelFlag(CommonConstant.DEL_FLAG_0);
@@ -60,8 +62,8 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	 */
 	@Override
 	public boolean resumeJob(QuartzJob quartzJob) {
-		schedulerDelete(quartzJob.getJobClassName().trim());
-		schedulerAdd(quartzJob.getJobClassName().trim(), quartzJob.getCronExpression().trim(), quartzJob.getParameter());
+		schedulerDelete(quartzJob.getId());
+		schedulerAdd(quartzJob);
 		quartzJob.setStatus(CommonConstant.STATUS_NORMAL);
 		return this.updateById(quartzJob);
 	}
@@ -73,10 +75,10 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	@Override
 	public boolean editAndScheduleJob(QuartzJob quartzJob) throws SchedulerException {
 		if (CommonConstant.STATUS_NORMAL.equals(quartzJob.getStatus())) {
-			schedulerDelete(quartzJob.getJobClassName().trim());
-			schedulerAdd(quartzJob.getJobClassName().trim(), quartzJob.getCronExpression().trim(), quartzJob.getParameter());
+			schedulerDelete(quartzJob.getId());
+			schedulerAdd(quartzJob);
 		}else{
-			scheduler.pauseJob(JobKey.jobKey(quartzJob.getJobClassName().trim()));
+			scheduler.pauseJob(JobKey.jobKey(quartzJob.getId()));
 		}
 		return this.updateById(quartzJob);
 	}
@@ -86,7 +88,7 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	 */
 	@Override
 	public boolean deleteAndStopJob(QuartzJob job) {
-		schedulerDelete(job.getJobClassName().trim());
+		schedulerDelete(job.getId());
 		boolean ok = this.removeById(job.getId());
 		return ok;
 	}
@@ -96,7 +98,7 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 		String jobName = quartzJob.getJobClassName().trim();
 		Date startDate = new Date();
 		String ymd = DateUtils.date2Str(startDate,DateUtils.yyyymmddhhmmss.get());
-		String identity =  jobName + ymd;
+		String identity =  quartzJob.getId() + ymd;
 		//3秒后执行 只执行一次
 		startDate.setTime(startDate.getTime()+3000L);
 		// 定义一个Trigger
@@ -104,9 +106,22 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 				.withIdentity(identity, JOB_TEST_GROUP)
 				.startAt(startDate)
 				.build();
-		// 构建job信息
-		JobDetail jobDetail = JobBuilder.newJob(getClass(jobName).getClass()).withIdentity(identity).usingJobData("parameter", quartzJob.getParameter()).build();
-		// 将trigger和 jobDetail 加入这个调度
+		JobDetail jobDetail=null;
+		String springId=quartzJob.getSpringId();
+		String springMethod=quartzJob.getSpringMethodName();
+		if(StringUtils.isNotBlank(springId)&&StringUtils.isNotBlank(springMethod)){
+			JobDataMap jobDataMap= new JobDataMap();
+			jobDataMap.put("scheduleJob",quartzJob);
+			jobDetail = JobBuilder.newJob(SpringJob.class)
+					.withIdentity(quartzJob.getId())
+					.usingJobData(jobDataMap)
+					.build();
+		}else if(StringUtils.isNotBlank(quartzJob.getJobClassName())){
+			// 构建job信息
+			jobDetail = JobBuilder.newJob(getClass(jobName).getClass()).withIdentity(identity).usingJobData("parameter", quartzJob.getParameter()).build();
+
+		}
+			// 将trigger和 jobDetail 加入这个调度
 		scheduler.scheduleJob(jobDetail, trigger);
 		// 启动scheduler
 		scheduler.start();
@@ -114,7 +129,7 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 
 	@Override
 	public void pause(QuartzJob quartzJob){
-		schedulerDelete(quartzJob.getJobClassName().trim());
+		schedulerDelete(quartzJob.getId());
 		quartzJob.setStatus(CommonConstant.STATUS_DISABLE);
 		this.updateById(quartzJob);
 	}
@@ -122,44 +137,60 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	/**
 	 * 添加定时任务
 	 * 
-	 * @param jobClassName
-	 * @param cronExpression
-	 * @param parameter
+	 * @param quartzJob
 	 */
-	private void schedulerAdd(String jobClassName, String cronExpression, String parameter) {
+	private void schedulerAdd(QuartzJob quartzJob) {
+		if(quartzJob==null){
+			throw new JeecgBootException("创建定时任务失败");
+		}
 		try {
 			// 启动调度器
 			scheduler.start();
+			JobDetail jobDetail=null;
+			String springId=quartzJob.getSpringId();
+			String springMethod=quartzJob.getSpringMethodName();
+			if(StringUtils.isNotBlank(springId)&&StringUtils.isNotBlank(springMethod)){
+				JobDataMap jobDataMap= new JobDataMap();
+				jobDataMap.put("scheduleJob",quartzJob);
+				jobDetail = JobBuilder.newJob(SpringJob.class)
+						.withIdentity(quartzJob.getId())
+						.usingJobData(jobDataMap)
+						.build();
+			}else if(StringUtils.isNotBlank(quartzJob.getJobClassName())){
+				// 构建job信息
+				jobDetail = JobBuilder.newJob(getClass(quartzJob.getJobClassName().trim()).getClass()).withIdentity(quartzJob.getId()).usingJobData("parameter", quartzJob.getParameter()).build();
 
-			// 构建job信息
-			JobDetail jobDetail = JobBuilder.newJob(getClass(jobClassName).getClass()).withIdentity(jobClassName).usingJobData("parameter", parameter).build();
+			}
 
 			// 表达式调度构建器(即任务执行的时间)
-			CronScheduleBuilder scheduleBuilder = CronScheduleBuilder.cronSchedule(cronExpression);
+			CronScheduleBuilder scheduleBuilder = CronScheduleBuilder.cronSchedule(quartzJob.getCronExpression());
 
 			// 按新的cronExpression表达式构建一个新的trigger
-			CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(jobClassName).withSchedule(scheduleBuilder).build();
-
-			scheduler.scheduleJob(jobDetail, trigger);
+			CronTrigger trigger = TriggerBuilder.newTrigger().withIdentity(quartzJob.getId()).withSchedule(scheduleBuilder).build();
+			if(jobDetail!=null) {
+				scheduler.scheduleJob(jobDetail, trigger);
+			}else{
+				throw new JeecgBootException("创建定时任务失败");
+			}
 		} catch (SchedulerException e) {
 			throw new JeecgBootException("创建定时任务失败", e);
 		} catch (RuntimeException e) {
 			throw new JeecgBootException(e.getMessage(), e);
 		}catch (Exception e) {
-			throw new JeecgBootException("后台找不到该类名：" + jobClassName, e);
+			throw new JeecgBootException("后台找不到该类名：" + quartzJob.getJobClassName().trim(), e);
 		}
 	}
 
 	/**
 	 * 删除定时任务
 	 * 
-	 * @param jobClassName
+	 * @param jobId
 	 */
-	private void schedulerDelete(String jobClassName) {
+	private void schedulerDelete(String jobId) {
 		try {
-			scheduler.pauseTrigger(TriggerKey.triggerKey(jobClassName));
-			scheduler.unscheduleJob(TriggerKey.triggerKey(jobClassName));
-			scheduler.deleteJob(JobKey.jobKey(jobClassName));
+			scheduler.pauseTrigger(TriggerKey.triggerKey(jobId));
+			scheduler.unscheduleJob(TriggerKey.triggerKey(jobId));
+			scheduler.deleteJob(JobKey.jobKey(jobId));
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 			throw new JeecgBootException("删除定时任务失败");

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/util/SpringUtils.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/util/SpringUtils.java
@@ -1,0 +1,100 @@
+package org.jeecg.modules.quartz.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringUtils implements BeanFactoryPostProcessor {
+
+
+	private static ConfigurableListableBeanFactory beanFactory; // Spring应用上下文环境
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+		SpringUtils.beanFactory = beanFactory;
+	}
+
+	/**
+	 * 获取对象
+	 *
+	 * @param name
+	 * @return Object 一个以所给名字注册的bean的实例
+	 * @throws org.springframework.beans.BeansException
+	 *
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T getBean(String name) throws BeansException {
+		return (T) beanFactory.getBean(name);
+	}
+
+
+	/**
+	 * 获取类型为requiredType的对象
+	 *
+	 * @param clz
+	 * @return
+	 * @throws org.springframework.beans.BeansException
+	 *
+	 */
+	public static <T> T getBean(Class<T> clz) throws BeansException {
+		@SuppressWarnings("unchecked")
+		T result = (T) beanFactory.getBean(clz);
+		return result;
+	}
+
+
+	/**
+	 * 如果BeanFactory包含一个与所给名称匹配的bean定义，则返回true
+	 *
+	 * @param name
+	 * @return boolean
+	 */
+	public static boolean containsBean(String name) {
+		return beanFactory.containsBean(name);
+	}
+
+
+	/**
+	 * 判断以给定名字注册的bean定义是一个singleton还是一个prototype。
+	 * 如果与给定名字相应的bean定义没有被找到，将会抛出一个异常（NoSuchBeanDefinitionException）
+	 *
+	 * @param name
+	 * @return boolean
+	 * @throws org.springframework.beans.factory.NoSuchBeanDefinitionException
+	 *
+	 */
+	public static boolean isSingleton(String name) throws NoSuchBeanDefinitionException {
+		return beanFactory.isSingleton(name);
+	}
+
+
+	/**
+	 * @param name
+	 * @return Class 注册对象的类型
+	 * @throws org.springframework.beans.factory.NoSuchBeanDefinitionException
+	 *
+	 */
+	public static Class<?> getType(String name) throws NoSuchBeanDefinitionException {
+		return beanFactory.getType(name);
+	}
+
+
+	/**
+	 * 如果给定的bean名字在bean定义中有别名，则返回这些别名
+	 *
+	 * @param name
+	 * @return
+	 * @throws org.springframework.beans.factory.NoSuchBeanDefinitionException
+	 *
+	 */
+	public static String[] getAliases(String name) throws NoSuchBeanDefinitionException {
+		return beanFactory.getAliases(name);
+	}
+
+	public static String[] getAllBean(){
+		return beanFactory.getBeanDefinitionNames();
+	}
+}

--- a/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/util/TaskUtil.java
+++ b/jeecg-boot/jeecg-boot-module-system/src/main/java/org/jeecg/modules/quartz/util/TaskUtil.java
@@ -1,0 +1,80 @@
+package org.jeecg.modules.quartz.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Date;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.jeecg.modules.quartz.entity.QuartzJob;
+
+@Slf4j
+public class TaskUtil {
+
+		/**
+		 * 通过反射调用scheduleJob中定义的方法
+		 *
+		 * @param scheduleJob
+		 */
+		@SuppressWarnings("unchecked")
+		public static void invokMethod(QuartzJob scheduleJob) {
+			Object object = null;
+			Class clazz = null;
+			boolean flag = true;
+			if (StringUtils.isNotBlank(scheduleJob.getSpringId())) {
+				object = SpringUtils.getBean(scheduleJob.getSpringId());
+			} /*else if (StringUtils.isNotBlank(scheduleJob.getJobClassName())) {
+				try {
+					clazz = Class.forName(scheduleJob.getJobClassName());
+					object = clazz.newInstance();
+				} catch (Exception e) {
+					flag = false;
+					e.printStackTrace();
+				}
+
+
+			}*/
+			if (object == null) {
+				flag = false;
+				log.error("任务spring bean 为空 = [" + scheduleJob.getSpringId() + "]---------------未启动成功，请检查是否配置正确！！！");
+				return;
+			}
+			clazz = object.getClass();
+			Method method = null;
+			try {
+				method = clazz.getDeclaredMethod(scheduleJob.getSpringMethodName(), new Class[] { String.class });
+			} catch (NoSuchMethodException e) {
+				flag = false;
+				log.error("任务执行方法不存在 = [" + scheduleJob.getSpringMethodName() + "]---------------未启动成功，方法名设置错误！！！");
+
+			} catch (SecurityException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			if (method != null) {
+				try {
+					method.invoke(object, scheduleJob.getParameter());
+				} catch (IllegalAccessException e) {
+					flag = false;
+
+					e.printStackTrace();
+				} catch (IllegalArgumentException e) {
+					flag = false;
+
+					e.printStackTrace();
+				} catch (InvocationTargetException e) {
+					flag = false;
+
+					e.printStackTrace();
+				}
+			}
+			if(flag){
+				log.error("任务 = [" + scheduleJob.getSpringId() +"."+scheduleJob.getSpringMethodName()+ "]----------启动成功");
+
+			}
+
+		}
+
+
+}


### PR DESCRIPTION
定时器原使用class名称当主键，很不方便，修改使用定时器保存的实体id作为区分定时器的key，增加定时器调用方法，可使用springId.method 的方法执行，具体使用是在原输入classname的输入框，输入spring:springBeanId.method  自动识别，定时器执行时查找指定spring bean的指定方法
添加了一个测试方法，输入spring:testSpringBean.test  ，保存执行会输出参数内容 