### PR TITLE
修复  菜单管理-编辑-默认跳转地址   不显示内容的bug

### DIFF
--- a/ant-design-vue-jeecg/src/views/system/modules/PermissionModal.vue
+++ b/ant-design-vue-jeecg/src/views/system/modules/PermissionModal.vue
@@ -294,7 +294,7 @@
 
         this.visible = true;
         this.loadTree();
-        let fieldsVal = pick(this.model,'name','perms','permsType','component','url','sortNo','menuType','status');
+        let fieldsVal = pick(this.model,'name','perms','permsType','component','redirect','url','sortNo','menuType','status');
         this.$nextTick(() => {
           this.form.setFieldsValue(fieldsVal)
         });


### PR DESCRIPTION
菜单管理-编辑-默认跳转地址   如果填写了内容并保存，再次编辑时，不会显示这些内容，实际上是有的。