### PR TITLE
修复bug，BasicDrawer结合useDescription，在生产环境中Description未正确渲染

### DIFF
--- a/jeecgboot-vue3/src/components/Description/src/useDescription.ts
+++ b/jeecgboot-vue3/src/components/Description/src/useDescription.ts
@@ -1,5 +1,6 @@
 import type { DescriptionProps, DescInstance, UseDescReturnType } from './typing';
 import { ref, getCurrentInstance, unref } from 'vue';
+import { tryOnUnmounted } from '@vueuse/core';
 import { isProdMode } from '/@/utils/env';
 
 export function useDescription(props?: Partial<DescriptionProps>): UseDescReturnType {
@@ -10,7 +11,12 @@ export function useDescription(props?: Partial<DescriptionProps>): UseDescReturn
   const loaded = ref(false);
 
   function register(instance: DescInstance) {
-    if (unref(loaded) && isProdMode()) {
+    isProdMode() &&
+      tryOnUnmounted(() => {
+        desc.value = null;
+        loaded.value = false;
+      });
+    if (unref(loaded) && isProdMode() && instance === unref(desc)) {
       return;
     }
     desc.value = instance;


### PR DESCRIPTION
场景：生产环境，在BasicDrawer中使用useDescription注册Description组件，并且给drawer配置了:destroy-on-close="true"属性，drawer在关闭后重新打开，Description组件未正确渲染。
原因：组件卸载时未重置加载状态，原先在生产环境下做了判断，若已加载，则不会重新注册。
