### PR TITLE
fix/linuxkit安装locale

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-start/Dockerfile
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-start/Dockerfile
@@ -6,7 +6,7 @@ RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
 #RUN mkdir -p /jeecg-boot/config/jeecg/
 
-# 解决linuxkit 精简镜像对 locale 裁剪导致中文乱码问题
+# 解决linuxkit 精简镜像对 locale 裁剪导致中文乱码问题 java:17-anolis基于anolis（CentOS/RHEL 系）应当使用yum
 RUN yum install -y --setopt=tsflags=nodocs \
         glibc-langpack-en \
         glibc-common \
@@ -25,4 +25,4 @@ ADD ./target/jeecg-system-start-3.9.1.jar ./
 
 RUN mkdir -p /jeecg-boot/config
 
-CMD sleep 60 && exec java -Dfile.encoding=UTF-8 -Djava.security.egd=file:/dev/./urandom -jar jeecg-system-start-3.9.1.jar
+CMD sleep 60 && exec java -Djava.security.egd=file:/dev/./urandom -jar jeecg-system-start-3.9.1.jar


### PR DESCRIPTION
解决linuxkit 精简镜像对 locale 裁剪导致jvm -Dfile.encoding=UTF-8 指定编码无效，进一步造成日志模块记录中文日志的乱码问题