### PR TITLE
修复第二次及其以后的编辑用户无法正常回显

### DIFF
--- a/jeecgboot-vue3/src/views/system/notice/NoticeModal.vue
+++ b/jeecgboot-vue3/src/views/system/notice/NoticeModal.vue
@@ -44,7 +44,7 @@
     setModalProps({ confirmLoading: false });
     isUpdate.value = !!data?.isUpdate;
     if (unref(isUpdate)) {
-      if (data.record.userIds) {
+      if (data.record.userIds && data.record.userIds.endsWith(",")) {
         data.record.userIds = data.record.userIds.substring(0, data.record.userIds.length - 1);
       }
       //表单赋值


### PR DESCRIPTION
复现：
第一次点击
<img width="1649" height="927" alt="image" src="https://github.com/user-attachments/assets/a23b573e-2e68-4230-946d-a6bbd28c68cd" />
然后直接关闭什么都不做，
第二次点击：
<img width="1846" height="929" alt="image" src="https://github.com/user-attachments/assets/e70e9495-e9d2-486a-845d-9ea46fffaed1" />
可以看到指定用户回显不正常