### PR TITLE
fix: add authentication check before loading sensitive AI tools in sendWithDefault()

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
@@ -1247,8 +1247,12 @@ public class AiragChatServiceImpl implements IAiragChatService {
             aiChatParams = new AIChatParams();
         }
         // 如果是默认app,加载系统默认工具
+        // Security fix: 仅已登录用户可加载敏感业务工具(add_user,grant_user_roles等),匿名用户仍可正常使用AI聊天
         if(chatConversation.getApp().getId().equals(AiAppConsts.DEFAULT_APP_ID)){
-            aiChatParams.setTools(jeecgToolsProvider.getDefaultTools());
+            String currentUser = getUsername(SpringContextUtils.getHttpServletRequest());
+            if(oConvertUtils.isNotEmpty(currentUser)){
+                aiChatParams.setTools(jeecgToolsProvider.getDefaultTools());
+            }
         }
         if(CollectionUtils.isEmpty(aiChatParams.getKnowIds())){
             aiChatParams.setKnowIds(chatConversation.getApp().getKnowIds());

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/airag/JeecgBizToolsProvider.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/airag/JeecgBizToolsProvider.java
@@ -1,6 +1,7 @@
 package org.jeecg.modules.airag;
 
-import com.alibaba.fastjson.JSON;
+import org.apache.shiro.SecurityUtils;
+import org.jeecg.common.system.vo.LoginUser;import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
@@ -52,16 +53,27 @@ public class JeecgBizToolsProvider implements JeecgToolsProvider {
 
     public Map<ToolSpecification, ToolExecutor> getDefaultTools(){
         Map<ToolSpecification, ToolExecutor> tools = new HashMap<>();
-        JeecgLlmTools userTool = queryUserTool();
-        tools.put(userTool.getToolSpecification(), userTool.getToolExecutor());
-        JeecgLlmTools addUser = addUserTool();
-        tools.put(addUser.getToolSpecification(), addUser.getToolExecutor());
-        // 新增：查询所有角色
-        JeecgLlmTools queryRoles = queryAllRolesTool();
-        tools.put(queryRoles.getToolSpecification(), queryRoles.getToolExecutor());
-        // 新增：给用户授予角色
-        JeecgLlmTools grantRoles = grantUserRolesTool();
-        tools.put(grantRoles.getToolSpecification(), grantRoles.getToolExecutor());
+        
+        if (SecurityUtils.getSubject().isPermitted("system:user:list")) {
+            JeecgLlmTools userTool = queryUserTool();
+            tools.put(userTool.getToolSpecification(), userTool.getToolExecutor());
+        }
+        
+        if (SecurityUtils.getSubject().isPermitted("system:user:add")) {
+            JeecgLlmTools addUser = addUserTool();
+            tools.put(addUser.getToolSpecification(), addUser.getToolExecutor());
+        }
+        
+        if (SecurityUtils.getSubject().isPermitted("system:role:list")) {
+            JeecgLlmTools queryRoles = queryAllRolesTool();
+            tools.put(queryRoles.getToolSpecification(), queryRoles.getToolExecutor());
+        }
+        
+        if (SecurityUtils.getSubject().isPermitted("system:user:addUserRole")) {
+            JeecgLlmTools grantRoles = grantUserRolesTool();
+            tools.put(grantRoles.getToolSpecification(), grantRoles.getToolExecutor());
+        }
+        
         return tools;
     }
 


### PR DESCRIPTION
## Problem

The `sendWithDefault()` method in `AiragChatServiceImpl.java` unconditionally loads 
sensitive business tools (`add_user`, `query_user_by_name`, `query_all_roles`, `grant_user_roles`) 
for the default AI application, regardless of whether the current user is authenticated.

Since the `/airag/chat/send` endpoint is intentionally designed as a public endpoint 
(`@IgnoreAuth`), this allows unauthenticated attackers to invoke these sensitive tools 
through natural language instructions, potentially creating backdoor admin accounts and 
achieving full system takeover.

## Root Cause

In `sendWithDefault()`, the code loads default tools without checking user authentication:

if(chatConversation.getApp().getId().equals(AiAppConsts.DEFAULT_APP_ID)){
    aiChatParams.setTools(jeecgToolsProvider.getDefaultTools());
    // No authentication check
}

## Fix

Added `getUsername()` check before `setTools()`. Only authenticated users can now access 
sensitive business tools. Anonymous users can still use AI chat normally (preserving 
the @IgnoreAuth design intent).

if(chatConversation.getApp().getId().equals(AiAppConsts.DEFAULT_APP_ID)){
    String currentUser = getUsername(SpringContextUtils.getHttpServletRequest());
    if(oConvertUtils.isNotEmpty(currentUser)){
        aiChatParams.setTools(jeecgToolsProvider.getDefaultTools());
    }
}

## Impact

- Sensitive tool loading is gated behind authentication

---
## Follow-up Update: Enhance Fine-Grained Authorization for AI Assistant (Follow-up to PR #9463)

### Description
This PR supplements and strengthens the authorization logic introduced in PR #9463 by addressing the lack of fine-grained permission control (vertical privilege escalation) within the AI Assistant module. The previous fix only verified whether a user was "logged in". This meant any authenticated low-privileged user (e.g., standard front-end user) could potentially utilize the AI Assistant to invoke or trigger sensitive backend tool execution like `add_user` or `grant_user_roles`, leading to unauthorized administrative actions and potential RCE.

### Key Changes
This PR introduces robust, granular **runtime `Shiro` permission checks** to the core AI tool provider `JeecgBizToolsProvider.java`, achieving a perfect defense line with minimal code changes:
1. **Dynamic ToolSpecification Pruning:**
   When registering and loading `getDefaultTools()` for the current LLM session, the system automatically validates whether the current logged-in user possesses the actual required backend business permissions (e.g., `system:user:add`) via `SecurityUtils.getSubject().isPermitted(...)`.

