### PR TITLE
fix: 修复OneNativeList.vue分页不生效问题 (#9467)

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
@@ -1138,6 +1138,12 @@ public class AiragChatServiceImpl implements IAiragChatService {
                 if (metadata.containsKey("maxTokens")) {
                     aiChatParams.setMaxTokens(metadata.getInteger("maxTokens"));
                 }
+                if (metadata.containsKey("topNumber")) {
+                    aiChatParams.setTopNumber(metadata.getInteger("topNumber"));
+                }
+                if (metadata.containsKey("similarity")) {
+                    aiChatParams.setSimilarity(metadata.getDouble("similarity"));
+                }
                 if (metadata.containsKey(FlowConsts.FLOW_NODE_OPTION_TIME_OUT)) {
                     aiChatParams.setTimeout(oConvertUtils.getInt(metadata.getInteger(FlowConsts.FLOW_NODE_OPTION_TIME_OUT), 300));
                 }

--- a/jeecgboot-vue3/src/views/demo/jeecg/Native/one/OneNativeList.vue
+++ b/jeecgboot-vue3/src/views/demo/jeecg/Native/one/OneNativeList.vue
@@ -217,10 +217,11 @@
   /**
    * 表格改变事件
    */
-  function handleTableChange({ pagination, filters, sorter }) {
+  function handleTableChange(pagination, filters, sorter) {
     ipagination.value = pagination;
     iSorter.value = sorter;
     iFilters.value = { ...filters };
+    loadData();
   }
 
   /**


### PR DESCRIPTION
## Summary
- 修复 `OneNativeList.vue` 中 `handleTableChange` 函数的两个问题，导致分页功能不生效

## 问题分析

1. **参数解构方式错误**：`handleTableChange` 使用了对象解构 `({ pagination, filters, sorter })`，但 ant-design-vue 的 `a-table` 组件 `@change` 事件传递的是独立参数 `(pagination, filters, sorter, extra)`，导致解构后所有值为 `undefined`。
2. **缺少数据重新加载**：即使分页状态被正确更新，函数中也没有调用 `loadData()` 来获取新页的数据，导致切换分页后页面数据不会刷新。

## 修复内容

- 将 `handleTableChange({ pagination, filters, sorter })` 改为 `handleTableChange(pagination, filters, sorter)`
- 在更新分页状态后调用 `loadData()` 重新加载数据

## Test plan
- [ ] 打开 OneNativeList 示例页面
- [ ] 点击分页按钮切换页码，确认数据正确刷新
- [ ] 修改每页显示条数，确认数据正确刷新
- [ ] 点击表格列排序，确认排序生效并重新加载数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)