### PR TITLE
fix: AI应用RAG参数(topNumber/similarity)未生效 (#9455)

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
@@ -1138,6 +1138,12 @@ public class AiragChatServiceImpl implements IAiragChatService {
                 if (metadata.containsKey("maxTokens")) {
                     aiChatParams.setMaxTokens(metadata.getInteger("maxTokens"));
                 }
+                if (metadata.containsKey("topNumber")) {
+                    aiChatParams.setTopNumber(metadata.getInteger("topNumber"));
+                }
+                if (metadata.containsKey("similarity")) {
+                    aiChatParams.setSimilarity(metadata.getDouble("similarity"));
+                }
                 if (metadata.containsKey(FlowConsts.FLOW_NODE_OPTION_TIME_OUT)) {
                     aiChatParams.setTimeout(oConvertUtils.getInt(metadata.getInteger(FlowConsts.FLOW_NODE_OPTION_TIME_OUT), 300));
                 }


### PR DESCRIPTION
## 问题描述

AI应用的RAG参数（`topNumber` 和 `similarity`）在 `AiragChatServiceImpl` 中未从 `aiApp.getMetadata()` 中提取并设置到 `AIChatParams` 上。

当前代码在解析 metadata 时，只设置了模型参数（temperature、topP、presencePenalty、frequencyPenalty、maxTokens、timeout），但遗漏了知识库检索相关的 `topNumber`（返回top结果数）和 `similarity`（相似度阈值）参数。这导致这两个参数始终使用默认值（topNumber=5, similarity=0.75），用户在AI应用中自定义的值不会生效。

## 修复方案

在 `AiragChatServiceImpl.java` 的 metadata 解析逻辑中，增加对 `topNumber` 和 `similarity` 的提取和设置，与其他参数保持一致的处理方式。

关联 #9455

🤖 Generated with [Claude Code](https://claude.com/claude-code)