### PR TITLE
fix: AI应用编辑接口跨租户写入漏洞修复 (#9462)

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/controller/AiragAppController.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/controller/AiragAppController.java
@@ -70,10 +70,17 @@ public class AiragAppController extends JeecgController<AiragApp, IAiragAppServi
      */
     @RequestMapping(value = "/edit", method = {RequestMethod.PUT, RequestMethod.POST})
     @RequiresPermissions("airag:app:edit")
-    public Result<String> edit(@RequestBody AiragApp airagApp) {
+    public Result<String> edit(@RequestBody AiragApp airagApp, HttpServletRequest request) {
         AssertUtils.assertNotEmpty("参数异常", airagApp);
         AssertUtils.assertNotEmpty("请输入应用名称", airagApp.getName());
         AssertUtils.assertNotEmpty("请选择应用类型", airagApp.getType());
+        //update-begin---author:jeecgai ---date:20260325  for：[issues/9462]跨租户写入漏洞修复------------
+        //如果是saas隔离的情况下，忽略客户端传入的tenantId，使用当前登录用户的租户ID
+        if (MybatisPlusSaasConfig.OPEN_SYSTEM_TENANT_CONTROL) {
+            String currentTenantId = TokenUtils.getTenantIdByRequest(request);
+            airagApp.setTenantId(currentTenantId);
+        }
+        //update-end---author:jeecgai ---date:20260325  for：[issues/9462]跨租户写入漏洞修复------------
         airagApp.setStatus(AiAppConsts.STATUS_ENABLE);
         airagAppService.saveOrUpdate(airagApp);
         return Result.OK("保存完成!", airagApp.getId());


### PR DESCRIPTION
## 问题描述
`AiragAppController.edit` 接口未校验 `tenantId`，攻击者可通过篡改请求体中的 `tenantId` 字段，跨租户将应用数据写入其他租户的数据空间，破坏多租户隔离机制。

## 修复方案
- 在 `edit` 方法中，当开启 SAAS 多租户隔离（`OPEN_SYSTEM_TENANT_CONTROL`）时，忽略客户端传入的 `tenantId`，强制使用当前登录用户 Token 中的租户 ID
- 修复方式与同控制器中 `delete` 方法的租户校验逻辑保持一致

## 测试计划
- [ ] 验证正常编辑 AI 应用功能不受影响
- [ ] 验证篡改 `tenantId` 后，数据仍写入当前用户所属租户
- [ ] 验证未开启多租户隔离时，编辑功能正常

Closes #9462

🤖 Generated with [Claude Code](https://claude.com/claude-code)