### PR TITLE
fix: 增强JDBC URL安全校验及数据源权限控制 (#9468)

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/security/JdbcSecurityUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/security/JdbcSecurityUtil.java
@@ -14,9 +14,14 @@ public class JdbcSecurityUtil {
      * 连接驱动漏洞 最新版本修复后，可删除相应的key
      * postgre：authenticationPluginClassName, sslhostnameverifier, socketFactory, sslfactory, sslpasswordcallback
      * https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-v7wg-cpwc-24m4
-     * 
+     * mysql: allowLoadLocalInfile, allowUrlInLocalInfile, allowLoadLocalInfileInPath, autoDeserialize
+     * h2: INIT, TRACE_LEVEL_SYSTEM_OUT
      */
-    public static final String[] notAllowedProps = new String[]{"authenticationPluginClassName", "sslhostnameverifier", "socketFactory", "sslfactory", "sslpasswordcallback"};
+    public static final String[] notAllowedProps = new String[]{
+        "authenticationPluginClassName", "sslhostnameverifier", "socketFactory", "sslfactory", "sslpasswordcallback",
+        "allowLoadLocalInfile", "allowUrlInLocalInfile", "allowLoadLocalInfileInPath", "autoDeserialize",
+        "INIT", "TRACE_LEVEL_SYSTEM_OUT"
+    };
 
     /**
      * 校验sql是否有特定的key
@@ -27,14 +32,35 @@ public class JdbcSecurityUtil {
         if(oConvertUtils.isEmpty(jdbcUrl)){
             return;
         }
-        String urlConcatChar = "?";
-        if(jdbcUrl.indexOf(urlConcatChar)<0){
+
+        // 同时检查 ? 和 ; 分隔符，防止通过分号方式（H2/MySQL）绕过校验
+        int questionMarkIndex = jdbcUrl.indexOf("?");
+        int semicolonIndex = jdbcUrl.indexOf(";");
+
+        if(questionMarkIndex < 0 && semicolonIndex < 0){
             return;
         }
-        String argString = jdbcUrl.substring(jdbcUrl.indexOf(urlConcatChar)+1);
-        String[] keyAndValues = argString.split("&");
+
+        // 收集所有参数：既检查 ? 后的参数，也检查 ; 后的参数
+        StringBuilder allArgs = new StringBuilder();
+        if(questionMarkIndex >= 0){
+            allArgs.append(jdbcUrl.substring(questionMarkIndex + 1));
+        }
+        if(semicolonIndex >= 0){
+            String semicolonPart = jdbcUrl.substring(semicolonIndex + 1);
+            if(allArgs.length() > 0){
+                allArgs.append("&");
+            }
+            // 将分号分隔的参数转换为 & 分隔，以便统一处理
+            allArgs.append(semicolonPart.replace(";", "&"));
+        }
+
+        String[] keyAndValues = allArgs.toString().split("&");
         for(String temp: keyAndValues){
-            String key = temp.split("=")[0];
+            if(oConvertUtils.isEmpty(temp)){
+                continue;
+            }
+            String key = temp.split("=")[0].trim();
             for(String prop: notAllowedProps){
                 if(prop.equalsIgnoreCase(key)){
                     throw new JeecgBootException("连接地址有安全风险，【"+key+"】");
@@ -42,5 +68,5 @@ public class JdbcSecurityUtil {
             }
         }
     }
-    
+
 }

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/controller/SysDataSourceController.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/controller/SysDataSourceController.java
@@ -121,6 +121,7 @@ public class SysDataSourceController extends JeecgController<SysDataSource, ISys
      */
     @AutoLog(value = "多数据源管理-添加")
     @Operation(summary = "多数据源管理-添加")
+    @RequiresPermissions("system:datasource:add")
     @PostMapping(value = "/add")
     public Result<?> add(@RequestBody SysDataSource sysDataSource) {
         // 代码逻辑说明: jdbc连接地址漏洞问题
@@ -141,6 +142,7 @@ public class SysDataSourceController extends JeecgController<SysDataSource, ISys
      */
     @AutoLog(value = "多数据源管理-编辑")
     @Operation(summary = "多数据源管理-编辑")
+    @RequiresPermissions("system:datasource:edit")
     @RequestMapping(value = "/edit", method ={RequestMethod.PUT, RequestMethod.POST})
     public Result<?> edit(@RequestBody SysDataSource sysDataSource) {
         // 代码逻辑说明: jdbc连接地址漏洞问题
@@ -161,6 +163,7 @@ public class SysDataSourceController extends JeecgController<SysDataSource, ISys
      */
     @AutoLog(value = "多数据源管理-通过id删除")
     @Operation(summary = "多数据源管理-通过id删除")
+    @RequiresPermissions("system:datasource:delete")
     @DeleteMapping(value = "/delete")
     public Result<?> delete(@RequestParam(name = "id") String id) {
         return sysDataSourceService.deleteDataSource(id);


### PR DESCRIPTION
## 概述

修复 #9468 报告的两个安全漏洞，防止低权限用户通过JDBC URL注入实现任意文件读取或远程代码执行。

## 漏洞修复

### 1. JdbcSecurityUtil — JDBC URL参数黑名单不完整

**问题：**
- `validate()` 方法仅检查 `?` 后的参数，H2使用 `;` 分隔参数可完全绕过校验
- 黑名单仅包含5个PostgreSQL参数，缺少MySQL和H2的危险参数
- 参数key未做trim处理，可通过空格绕过

**修复：**
- 同时解析 `?` 和 `;` 两种分隔符的参数
- 新增MySQL危险参数：`allowLoadLocalInfile`、`allowUrlInLocalInfile`、`allowLoadLocalInfileInPath`、`autoDeserialize`
- 新增H2危险参数：`INIT`、`TRACE_LEVEL_SYSTEM_OUT`
- 对参数key进行trim处理

### 2. SysDataSourceController — 缺少权限注解

**问题：** `add`、`edit`、`delete` 接口缺少 `@RequiresPermissions` 注解，任何已认证用户均可操作数据源。

**修复：** 为以下接口添加权限控制：
- `add` → `@RequiresPermissions("system:datasource:add")`
- `edit` → `@RequiresPermissions("system:datasource:edit")`
- `delete` → `@RequiresPermissions("system:datasource:delete")`

## 测试计划

- [ ] 验证包含 `?allowLoadLocalInfile=true` 的JDBC URL被正确拦截
- [ ] 验证包含 `;INIT=...` 的H2 JDBC URL被正确拦截
- [ ] 验证参数key含空格时仍能正确拦截
- [ ] 验证无权限用户无法访问 add/edit/delete 接口
- [ ] 验证有权限用户正常使用数据源管理功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)