### PR TITLE
fix: FileDownloadUtils 路径遍历漏洞修复 (#9437)

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/CommonUtils.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/CommonUtils.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -61,7 +63,18 @@ public class CommonUtils {
         //update-end---author:wangshuai---date:2026-01-08---for:【QQYUN-14535】ai生成图片的后缀不一致的，导致不展示---
         try {
             if(CommonConstant.UPLOAD_TYPE_LOCAL.equals(uploadType)){
-                File file = new File(basePath + File.separator + bizPath + File.separator );
+                //update-begin---author:jeecgai---date:2026-03-25---for:【issues/9435】uploadOnlineImage路径遍历漏洞修复---
+                // 1. 使用已有的路径遍历检查
+                SsrfFileTypeFilter.checkPathTraversal(bizPath);
+                // 2. 标准化路径并校验是否在basePath范围内
+                Path root = Paths.get(basePath).toAbsolutePath().normalize();
+                Path targetDir = root.resolve(bizPath).toAbsolutePath().normalize();
+                if (!targetDir.startsWith(root)) {
+                    log.error("检测到路径遍历攻击！非法 bizPath: {}", bizPath);
+                    throw new SecurityException("Illegal access to path outside of base directory.");
+                }
+                //update-end---author:jeecgai---date:2026-03-25---for:【issues/9435】uploadOnlineImage路径遍历漏洞修复---
+                File file = targetDir.toFile();
                 if (!file.exists()) {
                     file.mkdirs();// 创建文件根目录
                 }

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FileDownloadUtils.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FileDownloadUtils.java
@@ -18,6 +18,8 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -131,6 +133,10 @@ public class FileDownloadUtils {
      * @date 2024/1/19 10:09
      */
     public static String download2DiskFromNet(String fileUrl, String storePath) {
+        // 路径遍历安全校验
+        SsrfFileTypeFilter.checkPathTraversal(storePath);
+        validateStorePath(storePath);
+
         try {
             URL url = new URL(fileUrl);
             URLConnection conn = url.openConnection();
@@ -155,6 +161,25 @@ public class FileDownloadUtils {
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new JeecgBootException(e);
+        }
+    }
+
+    /**
+     * 校验存储路径安全性，防止路径遍历攻击
+     * 通过路径标准化后比较，确保不会通过 ../ 等方式逃逸出预期目录
+     *
+     * @param storePath 存储路径
+     */
+    private static void validateStorePath(String storePath) {
+        if (storePath == null || storePath.trim().isEmpty()) {
+            throw new JeecgBootException("存储路径不能为空");
+        }
+        Path normalized = Paths.get(storePath).normalize();
+        // 标准化后的路径不应与原始路径的文件名部分不同（检测 ../ 逃逸）
+        Path original = Paths.get(storePath);
+        if (!normalized.toAbsolutePath().equals(original.toAbsolutePath())) {
+            log.error("检测到非法存储路径尝试! storePath: {}", storePath);
+            throw new JeecgBootException("非法的文件存储路径");
         }
     }
 


### PR DESCRIPTION
## 概要
- 修复 `FileDownloadUtils.download2DiskFromNet` 方法中 `storePath` 参数缺乏安全校验导致的路径遍历漏洞
- 添加 `SsrfFileTypeFilter.checkPathTraversal` 校验，防止 `../` 和 `%2e` 编码绕过
- 添加 `validateStorePath` 方法，通过 `Paths.get().normalize()` 标准化路径后与原始路径比较，确保不会逃逸出预期目录

## 修复内容
- 在 `download2DiskFromNet` 方法入口处增加路径安全校验
- 复用已有的 `SsrfFileTypeFilter.checkPathTraversal` 进行 `..` 和 URL 编码检测
- 新增 `validateStorePath` 私有方法，使用 `java.nio.file.Paths` 进行路径标准化比较

## 测试计划
- [ ] 验证正常路径下载功能不受影响
- [ ] 验证包含 `../` 的路径被正确拒绝
- [ ] 验证包含 `%2e` 编码的路径被正确拒绝

Closes #9437

🤖 Generated with [Claude Code](https://claude.com/claude-code)