### PR TITLE
fix: uploadOnlineImage 路径遍历漏洞修复 (#9435)

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/CommonUtils.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/CommonUtils.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -61,7 +63,18 @@ public class CommonUtils {
         //update-end---author:wangshuai---date:2026-01-08---for:【QQYUN-14535】ai生成图片的后缀不一致的，导致不展示---
         try {
             if(CommonConstant.UPLOAD_TYPE_LOCAL.equals(uploadType)){
-                File file = new File(basePath + File.separator + bizPath + File.separator );
+                //update-begin---author:jeecgai---date:2026-03-25---for:【issues/9435】uploadOnlineImage路径遍历漏洞修复---
+                // 1. 使用已有的路径遍历检查
+                SsrfFileTypeFilter.checkPathTraversal(bizPath);
+                // 2. 标准化路径并校验是否在basePath范围内
+                Path root = Paths.get(basePath).toAbsolutePath().normalize();
+                Path targetDir = root.resolve(bizPath).toAbsolutePath().normalize();
+                if (!targetDir.startsWith(root)) {
+                    log.error("检测到路径遍历攻击！非法 bizPath: {}", bizPath);
+                    throw new SecurityException("Illegal access to path outside of base directory.");
+                }
+                //update-end---author:jeecgai---date:2026-03-25---for:【issues/9435】uploadOnlineImage路径遍历漏洞修复---
+                File file = targetDir.toFile();
                 if (!file.exists()) {
                     file.mkdirs();// 创建文件根目录
                 }


### PR DESCRIPTION
## 修复内容
- 修复 `CommonUtils.uploadOnlineImage` 方法中 `bizPath` 参数未校验导致的路径遍历漏洞
- 攻击者可通过构造包含 `../` 的恶意 `bizPath` 将文件写入任意目录

## 修复方案
1. 调用已有的 `SsrfFileTypeFilter.checkPathTraversal()` 方法检查 `bizPath` 是否包含 `..` 等非法字符
2. 使用 `java.nio.file.Path.normalize()` 标准化路径，并校验最终路径是否在 `basePath` 范围内，防止路径逃逸

## 测试计划
- [ ] 验证正常 bizPath（如 `ai/image`）上传功能正常
- [ ] 验证恶意 bizPath（如 `../../etc`）被正确拦截并抛出异常
- [ ] 验证 URL 编码绕过（如 `%2e%2e/`）被拦截

Closes #9435

🤖 Generated with [Claude Code](https://claude.com/claude-code)