### PR TITLE
fix: 全局开启 Fastjson SafeMode，修复反序列化漏洞

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/FastJsonSafeModeConfig.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/config/FastJsonSafeModeConfig.java
@@ -1,0 +1,30 @@
+package org.jeecg.config;
+
+import com.alibaba.fastjson.parser.ParserConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Fastjson 安全模式配置
+ * <p>
+ * 全局开启 SafeMode，禁用 autoType 功能，防止 Fastjson 反序列化漏洞（RCE）。
+ * 开启后，所有通过 JSON.parseObject / JSON.parseArray 的调用将拒绝解析 @type 字段，
+ * 从而阻止攻击者利用恶意类进行远程代码执行。
+ * </p>
+ *
+ * @see <a href="https://github.com/jeecgboot/JeecgBoot/issues/9433">#9433</a>
+ * @see <a href="https://github.com/jeecgboot/JeecgBoot/issues/9436">#9436</a>
+ * @see <a href="https://github.com/jeecgboot/JeecgBoot/issues/9439">#9439</a>
+ */
+@Slf4j
+@Configuration
+public class FastJsonSafeModeConfig {
+
+    @PostConstruct
+    public void enableSafeMode() {
+        ParserConfig.getGlobalInstance().setSafeMode(true);
+        log.info("Fastjson SafeMode 已全局开启，autoType 已禁用");
+    }
+}


### PR DESCRIPTION
## 修复问题
- closes #9433 - AiragVariableServiceImpl.additionalPrompt Fastjson 反序列化漏洞
- closes #9436 - SysBaseApiImpl.sendBusTemplateAnnouncement Fastjson 反序列化漏洞
- closes #9439 - WordTplUtils.renderDocumentBody Fastjson 反序列化漏洞

## 问题分析
项目多处使用 `JSON.parseObject` / `JSONArray.parseArray` 解析用户可控的 JSON 字符串，但未开启 Fastjson SafeMode。攻击者可通过构造含 `@type` 字段的恶意 JSON，利用 autoType 机制触发任意类实例化，导致远程代码执行（RCE）。

涉及的漏洞点：
1. `AiragVariableServiceImpl.additionalPrompt` - 解析用户通过 debug 接口传入的 variables 字段
2. `SysBaseApiImpl.sendBusTemplateAnnouncement` - 解析业务模板中的 MSG_ABSTRACT_JSON
3. `WordTplUtils.renderDocumentBody` - 解析数据库中存储的 Word 模板主内容

## 修复方案
在 `jeecg-boot-base-core` 模块新增 `FastJsonSafeModeConfig` 配置类，应用启动时通过 `@PostConstruct` 全局开启 `ParserConfig.getGlobalInstance().setSafeMode(true)`。

此方案的优势：
- **一次性修复**：覆盖项目中所有 Fastjson 反序列化调用点，无需逐个修改
- **最小改动**：仅新增一个配置类，不修改现有业务代码
- **基础模块生效**：配置在 base-core 模块，所有子模块自动继承

开启 SafeMode 后，Fastjson 将拒绝解析 `@type` 字段，彻底阻断 autoType 反序列化攻击链。

## 测试建议
- [ ] 验证应用正常启动，日志中输出 "Fastjson SafeMode 已全局开启"
- [ ] 验证 AI 应用调试接口（/airag/app/debug）正常工作
- [ ] 验证业务模板通告功能正常
- [ ] 验证 Word 模板导出功能正常
- [ ] 验证含 `@type` 的恶意 JSON 输入被正确拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)