### PR TITLE
fix: FillRuleUtil 反射加载增加包路径白名单校验 (#9438)

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FillRuleUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FillRuleUtil.java
@@ -73,8 +73,18 @@ public class FillRuleUtil {
                 if (formData == null) {
                     formData = new JSONObject();
                 }
-                // 通过反射执行配置的类里的方法
-                IFillRuleHandler ruleHandler = (IFillRuleHandler) Class.forName(ruleClass).newInstance();
+                // 包路径白名单校验，防止任意类加载漏洞
+                if (!ruleClass.startsWith("org.jeecg.")) {
+                    log.error("检测到非法填值规则类加载尝试: {}", ruleClass);
+                    throw new SecurityException("不允许加载非 org.jeecg 包路径下的填值规则类: " + ruleClass);
+                }
+
+                // 通过反射执行配置的类里的方法（先加载类并校验接口，再实例化）
+                Class<?> clazz = Class.forName(ruleClass);
+                if (!IFillRuleHandler.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException("类 " + ruleClass + " 未实现 IFillRuleHandler 接口");
+                }
+                IFillRuleHandler ruleHandler = (IFillRuleHandler) clazz.getDeclaredConstructor().newInstance();
                 return ruleHandler.execute(params, formData);
             } catch (Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
## 修复内容
修复 `FillRuleUtil.executeRule` 中不安全的反射调用漏洞（#9438）。

## 问题分析
原代码直接使用数据库中读取的 `ruleClass` 字符串执行 `Class.forName(ruleClass).newInstance()`，无任何白名单校验，存在以下风险：
- 攻击者可通过篡改 `sys_fill_rule` 表注入任意危险类
- `newInstance()` 在类型强转之前就已执行目标类的静态块和构造函数

## 修复方案
1. **包路径白名单校验**：仅允许加载 `org.jeecg.` 包路径下的类
2. **接口预检**：在实例化前校验目标类是否实现了 `IFillRuleHandler` 接口
3. **安全实例化**：使用 `clazz.getDeclaredConstructor().newInstance()` 替代已废弃的 `Class.newInstance()`

## 测试计划
- [ ] 验证正常填值规则（如 `org.jeecg.modules.system.rule.OrgCodeRule`）仍可正常执行
- [ ] 验证非 `org.jeecg` 包路径的类名被拒绝加载
- [ ] 验证未实现 `IFillRuleHandler` 接口的类被拒绝实例化

Closes #9438

🤖 Generated with [Claude Code](https://claude.com/claude-code)