### PR TITLE
fix: QuartzJobServiceImpl 反射实例化增加白名单校验，防止RCE漏洞 (#9430)

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
@@ -174,9 +174,20 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 		}
 	}
 
+	/**
+	 * 安全加载Job类：仅允许 org.jeecg. 包下的类，且必须实现 org.quartz.Job 接口
+	 */
 	private static Job getClass(String classname) throws Exception {
-		Class<?> class1 = Class.forName(classname);
-		return (Job) class1.newInstance();
+		// 包名白名单校验，防止任意类实例化导致RCE
+		if (classname == null || !classname.startsWith("org.jeecg.")) {
+			throw new IllegalArgumentException("非法的任务类名：" + classname + "，仅允许 org.jeecg 包下的Job类");
+		}
+		Class<?> clazz = Class.forName(classname);
+		// 校验是否实现了 org.quartz.Job 接口
+		if (!Job.class.isAssignableFrom(clazz)) {
+			throw new IllegalArgumentException("非法的任务类：" + classname + "，必须实现 org.quartz.Job 接口");
+		}
+		return (Job) clazz.getDeclaredConstructor().newInstance();
 	}
 
 }


### PR DESCRIPTION
## 问题描述
`QuartzJobServiceImpl.getClass(String classname)` 方法直接使用 `Class.forName(classname).newInstance()` 加载并实例化类，未做任何校验。攻击者可通过传入任意类名实现远程代码执行（RCE）。

## 修复方案
1. **包名白名单校验**：仅允许 `org.jeecg.` 包下的类被加载，拒绝其他任意类名
2. **接口类型校验**：校验加载的类是否实现了 `org.quartz.Job` 接口，防止非法类被实例化
3. **替换已废弃API**：将 `class.newInstance()` 替换为 `class.getDeclaredConstructor().newInstance()`

## 测试计划
- [ ] 验证正常的 `org.jeecg.` 包下的 Job 类可以正常加载和执行
- [ ] 验证非 `org.jeecg.` 包的类名被拒绝并抛出异常
- [ ] 验证未实现 `Job` 接口的类被拒绝并抛出异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)