### PR TITLE
fix: 修复OpenApiController SSRF漏洞和PluginToolBuilder路径遍历漏洞 (#9432, #9421)

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/PluginToolBuilder.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/PluginToolBuilder.java
@@ -8,6 +8,7 @@ import dev.langchain4j.service.tool.ToolExecutor;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
+import org.jeecg.common.exception.JeecgBootException;
 import org.jeecg.common.util.CommonUtils;
 import org.jeecg.common.util.RestUtil;
 import org.jeecg.common.util.TokenUtils;
@@ -277,6 +278,10 @@ public class PluginToolBuilder {
 
                 Object value = args.get(paramName);
                 if (value != null) {
+                    // 路径遍历防护：禁止Path参数中包含 .. 序列
+                    if (value.toString().contains("..")) {
+                        throw new JeecgBootException("Invalid path parameter: path traversal detected");
+                    }
                     url = url.replace("{" + paramName + "}", value.toString());
                 }
             }

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/openapi/controller/OpenApiController.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/openapi/controller/OpenApiController.java
@@ -34,7 +34,9 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -159,6 +161,8 @@ public class OpenApiController extends JeecgController<OpenApi, OpenApiService> 
         }
 
         String url = openApi.getOriginUrl();
+        // SSRF防护：校验originUrl不指向内网地址
+        validateUrlNotInternal(url);
         String method = openApi.getRequestMethod();
         String appkey = request.getHeader("appkey");
         OpenApiAuth openApiAuth = openApiAuthService.getByAppkey(appkey);
@@ -411,5 +415,60 @@ public class OpenApiController extends JeecgController<OpenApi, OpenApiService> 
         r.setCode(CommonConstant.SC_OK_200);
         r.setResult(PathGenerator.genPath());
         return r;
+    }
+
+    /**
+     * SSRF防护：校验URL不指向内网/私有地址
+     * @param urlStr 待校验的URL
+     */
+    private void validateUrlNotInternal(String urlStr) {
+        if (StrUtil.isEmpty(urlStr)) {
+            return;
+        }
+        try {
+            String host;
+            if (urlStr.startsWith("http://") || urlStr.startsWith("https://")) {
+                host = new URL(urlStr).getHost();
+            } else {
+                // 对于相对路径（如 /api/xxx），无需校验
+                return;
+            }
+            if (StrUtil.isEmpty(host)) {
+                return;
+            }
+            String hostLower = host.toLowerCase();
+            // 检查常见内网主机名
+            if ("localhost".equals(hostLower) || "127.0.0.1".equals(hostLower) || "0.0.0.0".equals(hostLower)) {
+                throw new IllegalArgumentException("请求地址不允许指向本地地址: " + host);
+            }
+            // 检查私有IP段
+            if (hostLower.startsWith("10.")
+                    || hostLower.startsWith("192.168.")
+                    || hostLower.startsWith("169.254.")) {
+                throw new IllegalArgumentException("请求地址不允许指向内网地址: " + host);
+            }
+            // 检查172.16.0.0 - 172.31.255.255
+            if (hostLower.startsWith("172.")) {
+                String[] parts = hostLower.split("\\.");
+                if (parts.length >= 2) {
+                    try {
+                        int second = Integer.parseInt(parts[1]);
+                        if (second >= 16 && second <= 31) {
+                            throw new IllegalArgumentException("请求地址不允许指向内网地址: " + host);
+                        }
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+            // DNS解析后二次校验，防止DNS重绑定到内网IP
+            InetAddress address = InetAddress.getByName(host);
+            if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress()) {
+                throw new IllegalArgumentException("请求地址解析后指向内网地址: " + host);
+            }
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("请求地址校验失败: " + urlStr, e);
+        }
     }
 }


### PR DESCRIPTION
## 概要
- 修复 `OpenApiController.call` 方法中的 SSRF 漏洞，对 `originUrl` 进行内网地址校验，禁止请求指向 `localhost`、`127.0.0.1`、`10.x`、`172.16-31.x`、`192.168.x`、`169.254.x` 等私有地址段，并通过 DNS 解析进行二次校验防止 DNS 重绑定攻击 (#9432)
- 修复 `PluginToolBuilder.buildUrl` 方法中的路径遍历漏洞，当 Path 参数值包含 `..` 时抛出异常，防止路径遍历攻击 (#9421)

## 测试计划
- [ ] 验证 OpenAPI 调用正常的外部 URL 仍可正常工作
- [ ] 验证 OpenAPI 调用内网地址（如 `http://127.0.0.1/xxx`）时被拦截
- [ ] 验证 PluginToolBuilder 正常的 Path 参数替换仍可正常工作
- [ ] 验证 PluginToolBuilder 包含 `..` 的 Path 参数被拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)