### PR TITLE
fix: add path traversal protection to AI image/file handlers

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/AIChatHandler.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/AIChatHandler.java
@@ -535,6 +535,7 @@ public class AIChatHandler implements IAIChatHandler {
                         }
                     } else {
                         // 本地文件
+                        SsrfFileTypeFilter.checkPathTraversal(imageUrl);
                         String filePath = uploadpath + File.separator + imageUrl;
                         SsrfFileTypeFilter.checkPathTraversal(filePath);
                         Path path = Paths.get(filePath);

--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/EmbeddingHandler.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/handler/EmbeddingHandler.java
@@ -29,6 +29,7 @@ import org.jeecg.ai.factory.AiModelOptions;
 import org.jeecg.common.exception.JeecgBootException;
 import org.jeecg.common.system.util.JwtUtil;
 import org.jeecg.common.util.*;
+import org.jeecg.common.util.filter.SsrfFileTypeFilter;
 import org.jeecg.modules.airag.common.handler.IEmbeddingHandler;
 import org.jeecg.modules.airag.common.vo.knowledge.KnowledgeSearchResult;
 import org.jeecg.modules.airag.llm.config.EmbedStoreConfigBean;
@@ -659,6 +660,7 @@ public class EmbeddingHandler implements IEmbeddingHandler {
         }
         String filePath = metadataJson.getString(LLMConsts.KNOWLEDGE_DOC_METADATA_FILEPATH);
         AssertUtils.assertNotEmpty("请先上传文件", filePath);
+        SsrfFileTypeFilter.checkPathTraversal(filePath);
         filePath = ensureFile(filePath);
 
         File docFile = new File(filePath);
@@ -725,6 +727,7 @@ public class EmbeddingHandler implements IEmbeddingHandler {
             filePath = tempFilePath;
         } else {
             //本地文件
+            SsrfFileTypeFilter.checkPathTraversal(filePath);
             filePath = uploadpath + File.separator + filePath;
         }
         return filePath;

--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/wordtpl/utils/WordUtil.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/wordtpl/utils/WordUtil.java
@@ -12,6 +12,7 @@ import org.apache.xmlbeans.XmlToken;
 import org.apache.xmlbeans.impl.xb.xmlschema.SpaceAttribute;
 import org.jeecg.common.exception.JeecgBootException;
 import org.jeecg.common.util.SpringContextUtils;
+import org.jeecg.common.util.filter.SsrfFileTypeFilter;
 import org.jeecg.common.util.oConvertUtils;
 import org.jeecg.modules.airag.wordtpl.consts.WordTitleEnum;
 import org.jeecg.modules.airag.wordtpl.dto.MergeColDTO;
@@ -713,6 +714,7 @@ public class WordUtil {
                         .getEnvironment()
                         .getProperty("jeecg.path.upload", "");
                 // 将本地图片读取到 InputStream
+                SsrfFileTypeFilter.checkPathTraversal(imageUrl);
                 String filePath = uploadPath + File.separator + imageUrl;
                 in = new FileInputStream(filePath);
             }


### PR DESCRIPTION
## Summary
- **#9431**: Add `SsrfFileTypeFilter.checkPathTraversal(imageUrl)` before path concatenation in `AIChatHandler.getFirstImageBase64` to validate the raw user input before it is joined with the upload path.
- **#9429**: Add `SsrfFileTypeFilter.checkPathTraversal(imageUrl)` in `WordUtil.addImage` before reading local image files, preventing directory traversal via crafted image paths in Word template data.
- **#9425**: Add `SsrfFileTypeFilter.checkPathTraversal(filePath)` in `EmbeddingHandler.ensureFile` before concatenating `filePath` with `uploadpath` in the local file branch.
- **#9424**: Add `SsrfFileTypeFilter.checkPathTraversal(filePath)` in `EmbeddingHandler.parseFileByMinerU` before the file path is passed to command execution, preventing path traversal in MinerU command arguments.

All four issues share the same fix pattern: validate user-supplied file paths with `SsrfFileTypeFilter.checkPathTraversal()` before they are concatenated with the upload base path or passed to system commands.

Closes #9431, closes #9429, closes #9425, closes #9424

## Test plan
- [ ] Verify that normal image/file upload and retrieval still works in AI chat, Word template export, and knowledge base embedding
- [ ] Verify that file paths containing `..` or `%2e` are rejected with a `JeecgBootException`
- [ ] Confirm no regressions in AI image generation, Word document image insertion, and MinerU file parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)