### PR TITLE
fix: 修复字典多选组件(JDictSelectTag)默认值回显为原始值的问题 (#9420)

### DIFF
--- a/jeecgboot-vue3/src/components/Form/src/jeecg/components/JDictSelectTag.vue
+++ b/jeecgboot-vue3/src/components/Form/src/jeecg/components/JDictSelectTag.vue
@@ -98,6 +98,18 @@
       const attrs = useAttrs();
       const [state, , , formItemContext] = useRuleFormItem(props, 'value', 'change');
       const getBindValue = Object.assign({}, unref(props), unref(attrs));
+
+      // fix: #9420 当 mode 为 multiple 时，将逗号分隔的字符串转为数组，以便正确回显标签
+      watch(
+        () => props.value,
+        (val) => {
+          const { mode } = unref<Recordable>(getBindValue);
+          if (mode === 'multiple' && typeof val === 'string' && val !== '') {
+            state.value = val.split(',');
+          }
+        },
+        { immediate: true }
+      );
       // 是否正在加载回显数据
       const loadingEcho = ref<boolean>(false);
       // 是否是首次加载回显，只有首次加载，才会显示 loading


### PR DESCRIPTION
## Summary
- 修复 `JDictSelectTag` 组件在 `mode='multiple'` 时，`defaultValue` 传入逗号分隔字符串（如 `'1,2'`）无法正确回显字典标签的问题

## Problem
当 `JDictSelectTag` 使用多选模式时，`value` 以逗号分隔字符串传入（如 `'1,2'`），但 ant-design-vue 的 Select 组件在 `multiple` 模式下需要数组格式（`['1', '2']`）才能正确匹配字典选项并显示标签。

## Solution
添加对 `props.value` 的监听，当 `mode` 为 `multiple` 时，自动将逗号分隔字符串拆分为数组格式。

Closes #9420