### PR TITLE
fix: 修复字典搜索接口keyword参数SQL注入漏洞 (#9491)

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/SqlInjectionUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/SqlInjectionUtil.java
@@ -34,7 +34,7 @@ public class SqlInjectionUtil {
 	/**
 	 * 字典专用—sql注入关键词
 	 */
-	private static String specialDictSqlXssStr = "exec |peformance_schema|information_schema|extractvalue|updatexml|geohash|gtid_subset|gtid_subtract|insert |select |delete |update |drop |count |chr |mid |master |truncate |char |declare |;|+|--";
+	private static String specialDictSqlXssStr = "exec |peformance_schema|information_schema|extractvalue|updatexml|geohash|gtid_subset|gtid_subtract|insert |select |delete |update |drop |count |chr |mid |master |truncate |char |declare |;|+|--|and |or |'|substring |substring(";
 	/**
 	 * 完整匹配的key，不需要考虑前空格
 	 */
@@ -43,6 +43,7 @@ public class SqlInjectionUtil {
 		FULL_MATCHING_KEYWRODS.add(";");
 		FULL_MATCHING_KEYWRODS.add("+");
 		FULL_MATCHING_KEYWRODS.add("--");
+		FULL_MATCHING_KEYWRODS.add("'");
 	}
 	
 	

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/service/impl/SysDictServiceImpl.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/system/service/impl/SysDictServiceImpl.java
@@ -564,10 +564,22 @@ public class SysDictServiceImpl extends ServiceImpl<SysDictMapper, SysDict> impl
 			}
 
 			if (oConvertUtils.isNotEmpty(keyword)) {
+				// 【安全】对keyword进行SQL注入检测和单引号转义，防止通过keyword参数进行SQL注入
+				SqlInjectionUtil.specialFilterContentForDictSql(keyword);
+				keyword = keyword.replace("'", "''");
+
 				// 判断是否是多选
 				if (keyword.contains(SymbolConstant.COMMA)) {
 					// 代码逻辑说明: JTC-529【表单设计器】 编辑页面报错，in参数采用双引号导致 ----
-					String inKeywords = "'" + String.join("','", keyword.split(",")) + "'";
+					String[] keywordArr = keyword.split(",");
+					StringBuilder inKeywordsBuilder = new StringBuilder();
+					for (int i = 0; i < keywordArr.length; i++) {
+						if (i > 0) {
+							inKeywordsBuilder.append(",");
+						}
+						inKeywordsBuilder.append("'").append(keywordArr[i].replace("'", "''")).append("'");
+					}
+					String inKeywords = inKeywordsBuilder.toString();
 					keywordSql = "(" + text + " in (" + inKeywords + ") or " + code + " in (" + inKeywords + "))";
 				} else {
 					keywordSql = "("+text + " like '%"+keyword+"%' or "+ code + " like '%"+keyword+"%')";


### PR DESCRIPTION
## Summary
- 修复 `/sys/dict/loadDict/{dictCode}` 接口 `keyword` 参数的 SQL 注入漏洞

## Problem
`SysDictServiceImpl.getFilterSql()` 方法中，`keyword` 参数直接拼接到 SQL 的 `LIKE` 和 `IN` 子句中，未进行 SQL 注入检测和单引号转义。攻击者可通过注入布尔表达式（如 `' and substring(password,1,1)='c' and username like '`）进行盲注，推断 `sys_user` 等表中的敏感字段（如 `password`、`salt`）。

字典专用黑名单 `specialDictSqlXssStr` 缺少 `and`、`or`、`'`、`substring` 等关键词，无法拦截此类攻击。

## Solution
1. **`SysDictServiceImpl.getFilterSql()`**: 在构建 SQL 前，对 `keyword` 调用 `SqlInjectionUtil.specialFilterContentForDictSql()` 进行注入检测，并对单引号进行转义（`'` → `''`）
2. **`SqlInjectionUtil`**: 字典专用黑名单增加 `and `、`or `、`'`、`substring `、`substring(` 关键词；`FULL_MATCHING_KEYWRODS` 列表增加 `'` 以支持单引号的精确匹配

## Files Changed
- `SqlInjectionUtil.java` - 字典SQL注入黑名单增加关键词，FULL_MATCHING_KEYWRODS增加单引号
- `SysDictServiceImpl.java` - keyword参数构建SQL前增加注入检测和单引号转义

Closes #9491