### PR TITLE
build: remove duplicate dependency and enforce supported JDK range

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,32 @@
+name: jeecgboot-codeql-scope
+
+paths:
+  - jeecg-boot
+  - jeecgboot-vue3/src
+  - jeecgboot-vue3/types
+
+paths-ignore:
+  # Build and dependency artifacts
+  - '**/target/**'
+  - '**/node_modules/**'
+  - '**/dist/**'
+  - '**/coverage/**'
+
+  # Non-production test/demo sources
+  - '**/src/test/**'
+  - jeecg-boot/jeecg-server-cloud/jeecg-visual/jeecg-cloud-test/**
+
+  # Local/cloud duplicated API package set: keep local-api variant
+  - jeecg-boot/jeecg-module-system/jeecg-system-api/jeecg-system-cloud-api/**
+
+  # Code templates and static vendor assets that create parser noise
+  - jeecg-boot/**/src/main/resources/jeecg/code-template*/**
+  - jeecg-boot/**/src/main/resources/static/**
+  - jeecgboot-vue3/public/**
+
+  # Frontend generated and non-runtime sources
+  - jeecgboot-vue3/tests/**
+  - jeecgboot-vue3/mock/**
+  - '**/*.min.js'
+  - '**/*.map'
+  - '**/*.d.ts'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL Scan
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+  schedule:
+    - cron: "23 2 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Build Java modules for CodeQL
+        if: matrix.language == 'java-kotlin'
+        run: >
+          mvn -B -ntp -f jeecg-boot/pom.xml
+          -Dmaven.test.skip=true
+          -DskipITs
+          -Dspring-boot.repackage.skip=true
+          clean compile
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Project Overview
+
+- Monorepo with Java backend (`jeecg-boot`) and Vue3/TS frontend (`jeecgboot-vue3`).
+- CI security scanning is defined under `.github/workflows/codeql.yml`
+  and `.github/codeql/codeql-config.yml`.
+
+## Setup
+
+- Java: Maven from `jeecg-boot` root (`mvn -f jeecg-boot/pom.xml ...`).
+- Frontend: pnpm in `jeecgboot-vue3`.
+
+## Verification Defaults
+
+- For workflow/config changes, verify file syntax and matrix/build settings.
+- Keep scanner scope focused on runtime source; exclude generated/vendor/
+  test artifacts explicitly.
+
+## PR Rules
+
+- Commit and push branch updates.
+- Run PR continuity before creating or updating a PR.
+- Do not dismiss reviews without explicit user direction.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,24 @@
+# Architecture
+
+## Monorepo Layout
+
+- `jeecg-boot/`: Java multi-module backend (Maven).
+- `jeecgboot-vue3/`: Vue3 + TypeScript frontend (Vite).
+- `.github/workflows/`: CI workflows.
+- `.github/codeql/`: CodeQL scan configuration.
+
+## Security Scanning Architecture
+
+- CodeQL runs as a language matrix:
+  - `java-kotlin` with manual Maven build for stable extraction.
+  - `javascript-typescript` with scoped source analysis.
+- Central path policy in `.github/codeql/codeql-config.yml`:
+  - include backend and frontend runtime sources,
+  - exclude generated, vendor, static bundle, and test paths to
+    reduce parser/duplicate noise.
+
+## Rationale
+
+The repository contains both runtime code and template/static assets.
+Scoped CodeQL extraction is required to keep security signal high and
+avoid SARIF warning saturation from non-runtime files.

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,22 @@
+# Agents / Skills / MCP Usage
+
+## Defaults
+
+- Use subagents for analysis and verification when tasks span multiple streams.
+- Use memory to persist durable repo/workflow decisions.
+- Use PR continuity checks before creating or updating PRs.
+
+## For CI/Security Workflow Changes
+
+Recommended support stack:
+
+- `systematic-debugging` for root cause isolation,
+- `github-actions-templates` for workflow structure,
+- `verification-before-completion` before claiming done,
+- `pr-continuity` before opening/updating PRs.
+
+## Expected Outputs
+
+- Minimal, production-safe config changes.
+- Clear path-scoping rationale to preserve coverage while reducing
+  scanner noise.

--- a/docs/coderabbit/review-commands.md
+++ b/docs/coderabbit/review-commands.md
@@ -1,0 +1,12 @@
+# CodeRabbit Review Commands
+
+Use these PR comments when AI review flow needs nudging:
+
+- `@coderabbitai review` — request a review pass.
+- `@coderabbitai resume` — resume when paused.
+- `@coderabbitai help` — list available commands.
+
+Guidelines:
+
+- Trigger once per state transition.
+- Keep PR description synchronized with actionable AI walkthrough feedback.

--- a/docs/engineering/acceptance-criteria.md
+++ b/docs/engineering/acceptance-criteria.md
@@ -1,0 +1,33 @@
+# Engineering Acceptance Criteria
+
+## Scope
+
+This repository contains a Java backend (`jeecg-boot`) and a
+Vue3/TypeScript frontend (`jeecgboot-vue3`).
+
+## Completion Rules
+
+1. Every change must have a reproducible verification step (command
+   output or workflow run).
+2. Security or CI pipeline changes must include explicit rationale and
+   affected paths.
+3. Pull requests must be linked to a canonical PR path and avoid
+   duplicate/open competing PRs.
+4. For scanning workflow updates, success requires:
+   - workflow syntax validity,
+   - per-language CodeQL job separation,
+   - noise controls that do not exclude application runtime source.
+
+## Minimum Verification
+
+- Workflow/config changes: validate YAML correctness and inspect generated diff.
+- Repository policy/docs changes: markdown renders and paths exist under `docs/**`.
+
+## Quality Bar
+
+- Avoid placeholder TODOs in merged workflow files.
+- Exclusions must be precise and explainable (no blanket `**/*`
+  removal of runtime code).
+- Keep production source coverage for:
+  - `jeecg-boot/**` (Java runtime modules)
+  - `jeecgboot-vue3/src/**` (frontend runtime code)

--- a/docs/engineering/harness-engineering.md
+++ b/docs/engineering/harness-engineering.md
@@ -1,0 +1,24 @@
+# Harness Engineering
+
+## Repository Runtime Surfaces
+
+- Backend: Maven multi-module Java project in `jeecg-boot`.
+- Frontend: Vite + Vue3 + TypeScript app in `jeecgboot-vue3`.
+- CI: GitHub Actions workflows under `.github/workflows`.
+
+## Validation Harness
+
+- Prefer fast, file-scoped validation for config updates.
+- For CodeQL changes:
+  - verify workflow and config files exist,
+  - verify language matrix and build-mode settings,
+  - verify path filters include runtime source and exclude
+    generated/vendor noise.
+
+## Evidence Storage
+
+Primary evidence must live in:
+
+- commit diffs,
+- PR discussion/history,
+- GitHub Actions workflow runs.

--- a/docs/operations/deploy-runbook.md
+++ b/docs/operations/deploy-runbook.md
@@ -1,0 +1,26 @@
+# Deploy / Operations Runbook
+
+## CI Security Scan Path
+
+This repository uses GitHub Actions CodeQL scanning for Java and
+JavaScript/TypeScript.
+
+## Operational Steps
+
+1. Push branch with workflow/config updates.
+2. Confirm `CodeQL Scan` workflow triggers on PR.
+3. Inspect per-language jobs:
+   - `Analyze (java-kotlin)`
+   - `Analyze (javascript-typescript)`
+4. Validate that alert noise decreases and runtime source remains analyzed.
+
+## Failure Handling
+
+- Java build failures: verify Maven module target and Java version (`17`).
+- Parse-noise regressions: review `paths-ignore` for
+  generated/template/vendor sources.
+
+## Security Note
+
+Prefer GitHub-hosted CodeQL actions and workflow artifacts over local
+scanner execution for canonical evidence.

--- a/docs/security/api-security-checklist.md
+++ b/docs/security/api-security-checklist.md
@@ -1,0 +1,20 @@
+# API Security Checklist
+
+Applicable when backend API behavior or security boundaries change.
+
+## Baseline
+
+- Authentication and authorization checks remain enforced.
+- No secrets committed to repository.
+- Dependency sources remain trusted and pinned by build tooling.
+
+## For This Repository
+
+- Java service endpoints are implemented under `jeecg-boot` modules.
+- CI security scanning (CodeQL) must keep runtime code in scope while
+  filtering generated/vendor artifacts.
+
+## PR Gate
+
+- Document any new exclusion in security scans and why it does not
+  remove runtime attack surface coverage.

--- a/docs/workflow/one-day-delivery-plan.md
+++ b/docs/workflow/one-day-delivery-plan.md
@@ -1,0 +1,23 @@
+# One-Day Delivery Plan
+
+## Objective
+
+Deliver small, reviewable changes within a day with CI verification and
+PR continuity.
+
+## Flow
+
+1. Reproduce and classify issue from logs/alerts.
+2. Apply minimal code/config changes.
+3. Run local validation commands relevant to changed files.
+4. Commit and push to a dedicated branch.
+5. Reuse existing canonical PR when present; otherwise open one new PR.
+6. Request AI review signal once and keep PR body synchronized with
+   review guidance.
+7. Enable auto-merge after approvals and required checks pass.
+
+## Constraints
+
+- Do not force-push protected branches.
+- Do not dismiss reviews without explicit user instruction.
+- Split unrelated fixes into follow-up PRs.

--- a/docs/workflow/pr-continuity.md
+++ b/docs/workflow/pr-continuity.md
@@ -1,0 +1,18 @@
+# PR Continuity Policy
+
+## Canonical PR Selection
+
+1. Reuse an existing open PR for the same branch if available.
+2. If duplicates exist, keep one canonical PR and mark others as duplicates.
+3. Keep commit history focused; avoid bundling unrelated fixes.
+
+## Review Flow
+
+- Check review state and CI checks after each push.
+- Request AI review when no AI review activity is present.
+- Enable auto-merge only when approvals and required checks are green.
+
+## Non-Blocking States
+
+`REVIEW_REQUIRED`, `CHANGES_REQUESTED`, or pending checks are triage
+states, not terminal blockers.

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml
@@ -55,12 +55,6 @@
             <groupId>org.jeecgframework.jimureport</groupId>
             <artifactId>jimubi-spring-boot3-starter</artifactId>
         </dependency>
-		<!-- AI大模型管理 -->
-		<dependency>
-			<groupId>org.jeecgframework.boot3</groupId>
-			<artifactId>jeecg-boot-module-airag</artifactId>
-			<version>${jeecgboot.version}</version>
-		</dependency>
 	</dependencies>
 	
 </project>

--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -575,6 +575,28 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+			<!-- 构建前校验JDK范围（支持17~24，25+请切换到受支持版本） -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-supported-java</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,25)</version>
+									<message>Unsupported JDK detected. Please use a supported JDK version from 17 to 24.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
             <!-- 打包跳过测试 -->
             <plugin>
 		        <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Superseded by #9501.

Reason: #9500 was opened from a branch based on fork main and unintentionally included unrelated files. A clean branch from upstream `main` is now used in #9501 with only the intended two POM changes for #9498.