### PR TITLE
build: remove duplicate dependency and enforce supported JDK range

### DIFF
--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml
@@ -55,12 +55,6 @@
             <groupId>org.jeecgframework.jimureport</groupId>
             <artifactId>jimubi-spring-boot3-starter</artifactId>
         </dependency>
-		<!-- AI大模型管理 -->
-		<dependency>
-			<groupId>org.jeecgframework.boot3</groupId>
-			<artifactId>jeecg-boot-module-airag</artifactId>
-			<version>${jeecgboot.version}</version>
-		</dependency>
 	</dependencies>
 	
 </project>

--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -575,6 +575,28 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+			<!-- 构建前校验JDK范围（支持17~24，25+请切换到受支持版本） -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.5.0</version>
+				<executions>
+					<execution>
+						<id>enforce-supported-java</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[17,25)</version>
+									<message>Unsupported JDK detected. Please use a supported JDK version from 17 to 24.</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
             <!-- 打包跳过测试 -->
             <plugin>
 		        <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- remove duplicated `jeecg-boot-module-airag` dependency declaration in `jeecg-system-biz` to eliminate malformed effective model warnings
- add Maven Enforcer `requireJavaVersion` guard (`[17,25)`) at parent build level to fail fast on unsupported JDKs (e.g. JDK 25)
- provide explicit error message aligned with documented support range 17~24

## Verification
- `mvn -B -ntp -f jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml -DskipTests validate` (before: duplicate dependency warning reproduced)
- `mvn -B -ntp -f jeecg-boot/jeecg-module-system/jeecg-system-biz/pom.xml -DskipTests -Denforcer.skip=true validate` (after: duplicate warning removed)
- `mvn -B -ntp -f jeecg-boot/pom.xml -DskipTests validate` (after: fast-fail with unsupported JDK message on JDK 25)
- `mvn -B -ntp -f jeecg-boot/pom.xml -pl jeecg-module-system/jeecg-system-biz -am -DskipTests -Denforcer.skip=true validate` (reactor validate success for affected modules)

Closes #9498
Related: #9499