### PR TITLE
chore: ignore Eclipse metadata and local agent cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,13 @@ derby.log
 .cursor
 .history
 .claude
+
+## eclipse metadata
+**/.classpath
+**/.factorypath
+**/.project
+**/.settings/
+
+## local agent runtime cache
+/registered_agents.json
+/task_agent_mapping.json


### PR DESCRIPTION
## Summary
- ignore Eclipse-generated metadata files (`.classpath`, `.factorypath`, `.project`, `.settings/`) across modules
- ignore root-level local runtime cache files (`/registered_agents.json`, `/task_agent_mapping.json`) used by agent tooling
- keep root-only anchoring for runtime cache ignores to avoid hiding similarly named files in submodules

## Verification
- `git status --short --branch` now shows only intended tracked changes instead of IDE/runtime noise
- `git check-ignore -v --non-matching -- registered_agents.json task_agent_mapping.json some/module/registered_agents.json some/module/task_agent_mapping.json` confirms root-only matching for cache files
- `PYTHONPATH="${OPENCODE_HOME:-$HOME/.config/opencode}" python3 -m scripts.lint_by_filetype --json` reports clean result for changed file group