### PR TITLE
Add ZIP file support to document vectorization

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/document/TikaDocumentParser.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/document/TikaDocumentParser.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 /**
  * tika文档解析器,重写langchain4j的TikaDocumentParser <br/>
@@ -87,6 +89,8 @@ public class TikaDocumentParser {
             } else if (FILE_SUFFIX.contains(ext.toLowerCase())) {
                 return parseDocExcelPdfUsingApachePoi(file);
             //update-end---author:wangshuai---date:2026-01-09---for:【QQYUN-14261】【AI】AI助手，支持多模态能力- 文档---
+            } else if ("zip".equalsIgnoreCase(ext)) {
+                return extractFromZip(file);
             } else {
                 throw new IllegalArgumentException("不支持的文件格式: " + FilenameUtils.getExtension(fileName));
             }
@@ -280,6 +284,48 @@ public class TikaDocumentParser {
             }
             return Document.from(text.toString());
         }
+    }
+
+    private Document extractFromZip(File file) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(file.toPath()))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    zis.closeEntry();
+                    continue;
+                }
+                String entryExt = FilenameUtils.getExtension(entry.getName()).toLowerCase();
+                byte[] bytes = toByteArray(zis);
+                try {
+                    Document doc = null;
+                    if ("txt".equals(entryExt) || "md".equals(entryExt) || "pdf".equals(entryExt)) {
+                        doc = extractByTika(new ByteArrayInputStream(bytes));
+                    } else if (FILE_SUFFIX.contains(entryExt)) {
+                        File tmp = File.createTempFile("zip_entry_", "." + entryExt);
+                        try {
+                            try (OutputStream os = Files.newOutputStream(tmp.toPath())) {
+                                os.write(bytes);
+                            }
+                            doc = parseDocExcelPdfUsingApachePoi(tmp);
+                        } finally {
+                            tmp.delete();
+                        }
+                    }
+                    if (doc != null && !Utils.isNullOrBlank(doc.text())) {
+                        sb.append(doc.text()).append("\n");
+                    }
+                } catch (Exception e) {
+                    // skip unparseable entry
+                }
+                zis.closeEntry();
+            }
+        }
+        String text = sb.toString();
+        if (Utils.isNullOrBlank(text)) {
+            throw new BlankDocumentException();
+        }
+        return Document.from(text);
     }
 
     private static byte[] toByteArray(InputStream inputStream) throws IOException {

--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/test/java/org/jeecg/modules/airag/test/TikaDocumentParserTest.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/test/java/org/jeecg/modules/airag/test/TikaDocumentParserTest.java
@@ -1,0 +1,55 @@
+package org.jeecg.modules.airag.test;
+
+import dev.langchain4j.data.document.Document;
+import org.apache.tika.parser.AutoDetectParser;
+import org.jeecg.modules.airag.llm.document.TikaDocumentParser;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TikaDocumentParserTest {
+
+    @Test
+    public void testParseZip() throws IOException {
+        File zip = File.createTempFile("test_zip_", ".zip");
+        try {
+            try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip.toPath()))) {
+                zos.putNextEntry(new ZipEntry("hello.txt"));
+                zos.write("Hello from zip".getBytes());
+                zos.closeEntry();
+            }
+            TikaDocumentParser parser = new TikaDocumentParser(AutoDetectParser::new, null, null, null);
+            Document doc = parser.parse(zip);
+            assertNotNull(doc);
+            assertTrue(doc.text().contains("Hello from zip"));
+        } finally {
+            zip.delete();
+        }
+    }
+
+    @Test
+    public void testParseZipWithDirectory() throws IOException {
+        File zip = File.createTempFile("test_zip_dir_", ".zip");
+        try {
+            try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(zip.toPath()))) {
+                zos.putNextEntry(new ZipEntry("subdir/"));
+                zos.closeEntry();
+                zos.putNextEntry(new ZipEntry("subdir/notes.txt"));
+                zos.write("Notes content".getBytes());
+                zos.closeEntry();
+            }
+            TikaDocumentParser parser = new TikaDocumentParser(AutoDetectParser::new, null, null, null);
+            Document doc = parser.parse(zip);
+            assertNotNull(doc);
+            assertTrue(doc.text().contains("Notes content"));
+        } finally {
+            zip.delete();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9530

The knowledge base couldn't process ZIP files. Added support for extracting and parsing files inside ZIP archives, delegating to the appropriate parser for each file type. Includes tests to verify it works correctly.