### PR TITLE
Pass context classloader to Class.forName calls

### DIFF
--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/system/util/ResourceUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/system/util/ResourceUtil.java
@@ -144,7 +144,7 @@ public class ResourceUtil {
      */
     private static void processEnumClass(String classname) {
         try {
-            Class<?> clazz = Class.forName(classname);
+            Class<?> clazz = Class.forName(classname, true, Thread.currentThread().getContextClassLoader());
             EnumDict enumDict = clazz.getAnnotation(EnumDict.class);
 
             if (enumDict != null) {

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FillRuleUtil.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/FillRuleUtil.java
@@ -74,7 +74,7 @@ public class FillRuleUtil {
                     formData = new JSONObject();
                 }
                 // 通过反射执行配置的类里的方法
-                IFillRuleHandler ruleHandler = (IFillRuleHandler) Class.forName(ruleClass).newInstance();
+                IFillRuleHandler ruleHandler = (IFillRuleHandler) Class.forName(ruleClass, true, Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
                 return ruleHandler.execute(params, formData);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/MyClassLoader.java
+++ b/jeecg-boot/jeecg-boot-base-core/src/main/java/org/jeecg/common/util/MyClassLoader.java
@@ -9,7 +9,7 @@ public class MyClassLoader extends ClassLoader {
 	public static Class getClassByScn(String className) {
 		Class myclass = null;
 		try {
-			myclass = Class.forName(className);
+			myclass = Class.forName(className, true, Thread.currentThread().getContextClassLoader());
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
 			throw new RuntimeException(className+" not found!");

--- a/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
+++ b/jeecg-boot/jeecg-module-system/jeecg-system-biz/src/main/java/org/jeecg/modules/quartz/service/impl/QuartzJobServiceImpl.java
@@ -175,8 +175,8 @@ public class QuartzJobServiceImpl extends ServiceImpl<QuartzJobMapper, QuartzJob
 	}
 
 	private static Job getClass(String classname) throws Exception {
-		Class<?> class1 = Class.forName(classname);
-		return (Job) class1.newInstance();
+		Class<?> class1 = Class.forName(classname, true, Thread.currentThread().getContextClassLoader());
+		return (Job) class1.getDeclaredConstructor().newInstance();
 	}
 
 }


### PR DESCRIPTION
Fixes #9537

Class.forName can fail to load classes in long-running production apps when using the default system classloader. Using the context classloader instead fixes this. Applied the fix to ResourceUtil, FillRuleUtil, MyClassLoader, and QuartzJobServiceImpl.