### PR TITLE
Close InputStream in parse

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/document/TikaDocumentParser.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/document/TikaDocumentParser.java
@@ -73,24 +73,25 @@ public class TikaDocumentParser {
         AssertUtils.assertNotEmpty("请选择文件", file);
         try {
             // 用于解析(使用FileInputStream避免file.toPath()在Linux非UTF-8环境下中文文件名报错)
-            InputStream isForParsing = new FileInputStream(file);
-            // 使用 Tika 自动检测 MIME 类型
-            String fileName = file.getName().toLowerCase();
-            //后缀
-            String ext = FilenameUtils.getExtension(fileName);
-            if (fileName.endsWith(".txt")
-                    || fileName.endsWith(".md")
-                    || fileName.endsWith(".pdf")) {
-                return extractByTika(isForParsing);
-            //update-begin---author:wangshuai---date:2026-01-09---for:【QQYUN-14261】【AI】AI助手，支持多模态能力- 文档---
-            } else if (FILE_SUFFIX.contains(ext.toLowerCase())) {
-                return parseDocExcelPdfUsingApachePoi(file);
-            //update-end---author:wangshuai---date:2026-01-09---for:【QQYUN-14261】【AI】AI助手，支持多模态能力- 文档---
-            } else {
-                throw new IllegalArgumentException("不支持的文件格式: " + FilenameUtils.getExtension(fileName));
+            try (InputStream isForParsing = new FileInputStream(file)) {
+                // 使用 Tika 自动检测 MIME 类型
+                String fileName = file.getName().toLowerCase();
+                //后缀
+                String ext = FilenameUtils.getExtension(fileName);
+                if (fileName.endsWith(".txt")
+                        || fileName.endsWith(".md")
+                        || fileName.endsWith(".pdf")) {
+                    return extractByTika(isForParsing);
+                //update-begin---author:wangshuai---date:2026-01-09---for:【QQYUN-14261】【AI】AI助手，支持多模态能力- 文档---
+                } else if (FILE_SUFFIX.contains(ext.toLowerCase())) {
+                    return parseDocExcelPdfUsingApachePoi(file);
+                //update-end---author:wangshuai---date:2026-01-09---for:【QQYUN-14261】【AI】AI助手，支持多模态能力- 文档---
+                } else {
+                    throw new IllegalArgumentException("不支持的文件格式: " + FilenameUtils.getExtension(fileName));
+                }
+                } catch (IOException e) {
+                throw new RuntimeException(e);
             }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Spotted something in jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/llm/document/TikaDocumentParser.java that might be worth a look: The resource opened there can leak if parse exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path — happy to close if this isn’t useful.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.