### PR TITLE
Support query parameters in menu paths

### DIFF
--- a/jeecgboot-vue3/src/router/helper/menuHelper.ts
+++ b/jeecgboot-vue3/src/router/helper/menuHelper.ts
@@ -31,7 +31,7 @@ function findMenuPath<T = Recordable>(treeData: T[], path: string, matchHide: bo
     if(!matchHide && n.hideMenu) {
       return false;
     }
-    return n.path === path
+    return n.path.split('?')[0] === path.split('?')[0]
   }) as Menu[];
 }
 
@@ -95,7 +95,7 @@ export function transformRouteToMenu(routeModList: AppRouteModule[], routerMappi
         name: title,
         hideMenu,
         alwaysShow:node.alwaysShow||false,
-        path: node.path,
+        path: node.meta?.menuPath || node.path,
         originComponent: node.originComponent,
         ...(node.redirect ? { redirect: node.redirect } : {}),
       };

--- a/jeecgboot-vue3/src/router/helper/routeHelper.ts
+++ b/jeecgboot-vue3/src/router/helper/routeHelper.ts
@@ -79,6 +79,11 @@ function asyncImportRoute(routes: AppRouteRecordRaw[] | undefined) {
     if (!item.component && item.meta?.frameSrc) {
       item.component = 'IFRAME';
     }
+    if (item.path?.startsWith('/') && item.path.includes('?')) {
+      item.meta = item.meta || {};
+      item.meta.menuPath = item.path;
+      item.path = item.path.split('?')[0];
+    }
     let { component, name } = item;
     const { children } = item;
     if (component) {

--- a/jeecgboot-vue3/src/router/menus/index.ts
+++ b/jeecgboot-vue3/src/router/menus/index.ts
@@ -104,18 +104,19 @@ export async function getChildrenMenus(parentPath: string) {
 
 function basicFilter(routes: RouteRecordNormalized[]) {
   return (menu: Menu) => {
+    const menuBasePath = menu.path.split('?')[0];
     const matchRoute = routes.find((route) => {
       if (isUrl(menu.path)) return true;
 
       if (route.meta?.carryParam) {
-        return pathToRegexp(route.path).test(menu.path);
+        return pathToRegexp(route.path).test(menuBasePath);
       }
-      const isSame = route.path === menu.path;
+      const isSame = route.path === menuBasePath;
       if (!isSame) return false;
 
       if (route.meta?.ignoreAuth) return true;
 
-      return isSame || pathToRegexp(route.path).test(menu.path);
+      return isSame || pathToRegexp(route.path).test(menuBasePath);
     });
 
     if (!matchRoute) return false;


### PR DESCRIPTION
Fixes #9559

Menu routes with query parameters weren't matching correctly. Stored the full path in meta.menuPath while the route uses the base path. Updated all the path comparisons to ignore query params when matching menu items to routes.