### PR TITLE
fix(airag): preserve attachments when merging chat messages

### DIFF
--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/main/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImpl.java
@@ -387,7 +387,7 @@ public class AiragChatServiceImpl implements IAiragChatService {
                 }
                 // 合并文件
                 if (CollectionUtils.isNotEmpty(currMsg.getFiles())) {
-                    List<MessageHistory.FileHistory> files = CollectionUtils.isEmpty(cacheMsg.getImages()) ? new ArrayList<>() : cacheMsg.getFiles();
+                    List<MessageHistory.FileHistory> files = CollectionUtils.isEmpty(cacheMsg.getFiles()) ? new ArrayList<>() : cacheMsg.getFiles();
                     files.addAll(currMsg.getFiles());
                     cacheMsg.setFiles(files);
                 }
@@ -415,8 +415,8 @@ public class AiragChatServiceImpl implements IAiragChatService {
                             .topicId(message.getTopicId())
                             .role(message.getRole())
                             .content("")
-                            .images(message.getImages())
-                            .files(message.getFiles())
+                            .images(new ArrayList<>())
+                            .files(new ArrayList<>())
                             .datetime(message.getDatetime())
                             .build();
                 }

--- a/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/test/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImplTest.java
+++ b/jeecg-boot/jeecg-boot-module/jeecg-boot-module-airag/src/test/java/org/jeecg/modules/airag/app/service/impl/AiragChatServiceImplTest.java
@@ -1,0 +1,43 @@
+package org.jeecg.modules.airag.app.service.impl;
+
+import org.jeecg.modules.airag.common.consts.AiragConsts;
+import org.jeecg.modules.airag.common.vo.MessageHistory;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiragChatServiceImplTest {
+
+    @Test
+    void shouldKeepFilesFromConsecutiveAiMessagesWithoutImages() throws Exception {
+        MessageHistory firstMessage = aiMessage("first", "first.xlsx");
+        MessageHistory secondMessage = aiMessage("second", "second.xlsx");
+
+        List<MessageHistory> mergedMessages = mergeToolMessages(List.of(firstMessage, secondMessage));
+
+        assertEquals(1, mergedMessages.size());
+        List<MessageHistory.FileHistory> files = mergedMessages.get(0).getFiles();
+        assertEquals(List.of("first.xlsx", "second.xlsx"), files.stream()
+                .map(MessageHistory.FileHistory::getFilePath)
+                .toList());
+    }
+
+    private MessageHistory aiMessage(String content, String filePath) {
+        return MessageHistory.builder()
+                .role(AiragConsts.MESSAGE_ROLE_AI)
+                .content(content)
+                .files(List.of(new MessageHistory.FileHistory(filePath)))
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<MessageHistory> mergeToolMessages(List<MessageHistory> histories) throws Exception {
+        AiragChatServiceImpl service = new AiragChatServiceImpl();
+        Method method = AiragChatServiceImpl.class.getDeclaredMethod("mergeToolMessages", List.class, boolean.class);
+        method.setAccessible(true);
+        return (List<MessageHistory>) method.invoke(service, histories, false);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix attachment merging for consecutive AI messages.
- Initialize merged message media collections independently from source history.
- Preserve all file attachments when consecutive AI messages do not contain images.
- Add a regression test for file attachment merging.

## Verification

- Added `AiragChatServiceImplTest` covering consecutive AI messages with file attachments.
- `git diff --check` passed.

Related to #9777