### PR TITLE
fix: upgrade com.fasterxml.jackson.core:jackson-databind to 2.18.8, 2.21.4, 3.1.4 (CVE-2026-54513)

### DIFF
--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -83,8 +83,6 @@
 		<qiniu-java-sdk.version>7.4.0</qiniu-java-sdk.version>
 		<jedis.version>7.1.0</jedis.version>
 		<baidu-java-sdk.version>4.16.19</baidu-java-sdk.version>
-		<!-- jackson CVE-2026-54513: security bypass allows arbitrary code execution -->
-		<jackson-databind.version>2.18.8</jackson-databind.version>
 	</properties>
 
 	<modules>
@@ -590,7 +588,7 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>${jackson-databind.version}</version>
+				<version>2.18.8</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/jeecg-boot/pom.xml
+++ b/jeecg-boot/pom.xml
@@ -83,6 +83,8 @@
 		<qiniu-java-sdk.version>7.4.0</qiniu-java-sdk.version>
 		<jedis.version>7.1.0</jedis.version>
 		<baidu-java-sdk.version>4.16.19</baidu-java-sdk.version>
+		<!-- jackson CVE-2026-54513: security bypass allows arbitrary code execution -->
+		<jackson-databind.version>2.18.8</jackson-databind.version>
 	</properties>
 
 	<modules>
@@ -583,6 +585,12 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
 				<version>1.27.1</version>
+			</dependency>
+			<!-- CVE-2026-54513: override jackson-databind to fix security bypass -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
+				<version>${jackson-databind.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.15.4 to 2.18.8, 2.21.4, 3.1.4 to fix CVE-2026-54513.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-54513 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-54513` |
| **File** | `jeecg-boot/jeecg-boot-base-core/pom.xml` |
| **Assessment** | Likely exploitable |

**Description**: jackson-databind: Jackson-databind: Security bypass allows arbitrary code execution

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-54513` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `jeecg-boot/pom.xml`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
